### PR TITLE
fix missing step in command line example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ For more information, "[Information Sharing and Taxonomies Practical Classi cati
 ~~~~shell
 $ cd /var/www/MISP/app/files/taxonomies/
 $ mkdir privatetaxonomy
+$ cd privatetaxonomy
 $ vi machinetag.json
 ~~~~
 


### PR DESCRIPTION
command line example starting on line 76 missed a step, and if followed, results in the machinetag.json file being created in the wrong directory