### PR TITLE
Domain name abuse taxonomy

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -40,6 +40,11 @@
       "name": "dni-ism",
       "version": 3
     },
+     {
+      "description": "Taxonomy to tag domain names used for cybercrime.",
+      "name": "domain-abuse",
+      "version": 1
+    },
     {
       "description": "eCSIRT incident classification Appendix C of the eCSIRT EU project including IntelMQ updates.",
       "name": "ecsirt",

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following taxonomies are described:
 - [Cyber Kill Chain](./kill-chain) from Lockheed Martin
 - DE German (DE) [Government classification markings (VS)](./de-vs)
 - [DHS CIIP Sectors](./dhs-ciip-sectors)
+- [Domain Name Abuse](./domain-abuse)
 - [eCSIRT](./ecsirt) and IntelMQ incident classification
 - [ENISA](./enisa) ENISA Threat Taxonomy
 - [Estimative Language](./estimative-language) Estimative Language (ICD 203)
@@ -59,6 +60,11 @@ Taxonomy for the handling of protectively marked information in MISP with German
 ### [DHS CIIP Sectors](./dhs-ciip-sectors)
 
 DHS critical sectors as described in https://www.dhs.gov/critical-infrastructure-sectors.
+
+### [Domain Name Abuse](./domain-abuse)
+
+Taxonomy to tag domain names used for cybercrime. 
+We suggest to use europol-incident(./europol-incident) to tag abuse-activity.
 
 ### [eCSIRT](./ecsirt) and IntelMQ incident classification
 

--- a/domain-abuse/machinetag.json
+++ b/domain-abuse/machinetag.json
@@ -1,0 +1,80 @@
+{
+  "namespace": "domain-abuse",
+  "expanded": "Domain Name Abuse",
+  "description": "Domain Name Abuse - taxonomy to tag domain names used for cybercrime. Use europol-incident to tag abuse-activity",
+  "version": 1,
+  "predicates": [
+    {
+      "value": "domain-access-method",
+      "description": "Domain Access - describes how the adversary has gained access to the domain name",
+      "expanded": "Domain access method"
+    },
+    {
+      "value": "domain-status",
+      "description": "Domain status - describes the registration status of the domain name",
+      "expanded": "Domain status"
+    }
+  ],
+  "values": [
+    {
+      "predicate": "domain-status",
+      "entry": [
+        {
+          "value": "active",
+          "expanded": "Registered & active",
+          "description": "Domain name is registered and DNS is delegated"    
+        },
+         {
+          "value": "inactive",
+          "expanded": "Registered & inactive",
+          "description": "Domain name is registered and DNS is not delegated"
+        },
+        {
+          "value": "suspended",
+          "expanded": "Registered & suspended",
+          "description": "Domain name is registered & DNS delegation is temporarily removed by the registry"
+        },
+         {
+          "value": "not-registered",
+          "expanded": "Not registered",
+          "description": "Domain name is not registered and open for registration"
+        },
+         {
+          "value": "not-registrable",
+          "expanded": "Not registrable",
+          "description": "Domain is not registered and cannot be registered"
+        },
+    	{
+          "value": "grace-period",
+          "expanded": "Grace period",
+          "description": "Domain is deleted and still reserved for previous owner"
+        }
+      ]
+    },
+    {
+      "predicate": "domain-access-method",
+      "entry": [
+        {
+          "value": "criminal-registration",
+          "expanded": "Criminal registration",
+          "description": "Domain name is registered for criminal purposes"    
+        },
+        {
+          "value": "compromised-webserver",
+          "expanded": "Compromised webserver",
+          "description": "Webserver is compromised for criminal purposes"    
+        },
+        {
+          "value": "compromised-dns",
+          "expanded": "Compromised DNS",
+          "description": "Compromised authoritative DNS or compromised delegation"    
+        },
+        {
+          "value": "sinkhole",
+          "expanded": "Sinkhole",
+          "description": "Domain Name is sinkholed for research, detection, LE"    
+        }
+      ]  
+    }
+  ]
+}


### PR DESCRIPTION
taxonomy to tag domain names used for cybercrime. 
Written at TF-CSIRT hackathon by @sykaeh & @mausding from @switch-ch