### PR TITLE
Galaxy elements as taxonomies

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "version": "20161009",
+  "version": "20161026",
   "license": "CC-0",
   "description": "Manifest file of MISP taxonomies available.",
   "url": "https://raw.githubusercontent.com/MISP/misp-taxonomies/master/",
@@ -109,6 +109,11 @@
       "description": "Internal MISP taxonomy.",
       "name": "misp",
       "version": 3
+    },
+    {
+      "description": "Internal MISP galaxy taxonomy bridging the galaxy with the taxonomies temporarily",
+      "name": "misp-galaxy",
+      "version": 1
     },
     {
       "description": "Malware Type and Platform classification based on Microsoft's implementation of the Computer Antivirus Research Organization (CARO) Naming Scheme and Malware Terminology.",

--- a/misp-galaxy/machinetag.json
+++ b/misp-galaxy/machinetag.json
@@ -1,0 +1,1119 @@
+{
+    "description": "Elements from the misp-galaxy as taxonomy (temporary measure)",
+    "namespace": "misp-galaxy",
+    "predicates": [
+        {
+            "expanded": "threat-actor-tools is an enumeration of tools used by adversaries. The list includes malware but also common software regularly used by the adversaries.",
+            "value": "threat-actor-tool"
+        },
+        {
+            "expanded": "Known or estimated adversary groups targeting organizations and employees. Adversary groups are regularly confused with their initial operation or campaign.",
+            "value": "adversary-group"
+        }
+    ],
+    "values": [
+        {
+            "entry": [
+                {
+                    "description": "Malware",
+                    "expanded": "PlugX",
+                    "value": "PlugX"
+                },
+                {
+                    "expanded": "MSUpdater",
+                    "value": "MSUpdater"
+                },
+                {
+                    "description": "A password recovery tool regularly used by attackers",
+                    "expanded": "Lazagne",
+                    "value": "Lazagne"
+                },
+                {
+                    "description": "Poison Ivy is a RAT which was freely available and first released in 2005.",
+                    "expanded": "Poison Ivy",
+                    "value": "Poison Ivy"
+                },
+                {
+                    "description": "In March 2016, Unit 42 observed this new Poison Ivy variant we\u2019ve named SPIVY being deployed via weaponized documents leveraging CVE-2015-2545.",
+                    "expanded": "SPIVY",
+                    "value": "SPIVY"
+                },
+                {
+                    "expanded": "Torn RAT",
+                    "value": "Torn RAT"
+                },
+                {
+                    "expanded": "OzoneRAT",
+                    "value": "OzoneRAT"
+                },
+                {
+                    "expanded": "ZeGhost",
+                    "value": "ZeGhost"
+                },
+                {
+                    "description": "Backdoor.Dripion was custom developed, deployed in a highly targeted fashion, and used command and control servers disguised as antivirus company websites.",
+                    "expanded": "Backdoor.Dripion",
+                    "value": "Backdoor.Dripion"
+                },
+                {
+                    "expanded": "Elise Backdoor",
+                    "value": "Elise Backdoor"
+                },
+                {
+                    "description": "A new information stealer, Trojan.Laziok, acts as a reconnaissance tool allowing attackers to gather information and tailor their attack methods for each compromised computer.",
+                    "expanded": "Trojan.Laziok",
+                    "value": "Trojan.Laziok"
+                },
+                {
+                    "description": "Android-based malware",
+                    "expanded": "Slempo",
+                    "value": "Slempo"
+                },
+                {
+                    "description": "We have discovered a malware family named \u2018PWOBot\u2019 that is fairly unique because it is written entirely in Python, and compiled via PyInstaller to generate a Microsoft Windows executable. The malware has been witnessed affecting a number of Europe-based organizations, particularly in Poland. Additionally, the malware is delivered via a popular Polish file-sharing web service.",
+                    "expanded": "PWOBot",
+                    "value": "PWOBot"
+                },
+                {
+                    "expanded": "Lstudio",
+                    "value": "Lstudio"
+                },
+                {
+                    "expanded": "Joy RAT",
+                    "value": "Joy RAT"
+                },
+                {
+                    "expanded": "Lost Door RAT",
+                    "value": "Lost Door RAT"
+                },
+                {
+                    "expanded": "njRAT",
+                    "value": "njRAT"
+                },
+                {
+                    "expanded": "NanoCoreRAT",
+                    "value": "NanoCoreRAT"
+                },
+                {
+                    "expanded": "Sakula",
+                    "value": "Sakula"
+                },
+                {
+                    "expanded": "Derusbi",
+                    "value": "Derusbi"
+                },
+                {
+                    "expanded": "EvilGrab",
+                    "value": "EvilGrab"
+                },
+                {
+                    "expanded": "IEChecker",
+                    "value": "IEChecker"
+                },
+                {
+                    "expanded": "Trojan.Naid",
+                    "value": "Trojan.Naid"
+                },
+                {
+                    "expanded": "Backdoor.Moudoor",
+                    "value": "Backdoor.Moudoor"
+                },
+                {
+                    "expanded": "NetTraveler",
+                    "value": "NetTraveler"
+                },
+                {
+                    "expanded": "Winnti",
+                    "value": "Winnti"
+                },
+                {
+                    "expanded": "Mimikatz",
+                    "value": "Mimikatz"
+                },
+                {
+                    "expanded": "WEBC2",
+                    "value": "WEBC2"
+                },
+                {
+                    "expanded": "Pirpi",
+                    "value": "Pirpi"
+                },
+                {
+                    "expanded": "RARSTONE",
+                    "value": "RARSTONE"
+                },
+                {
+                    "expanded": "BACKSPACe",
+                    "value": "BACKSPACe"
+                },
+                {
+                    "expanded": "XSControl",
+                    "value": "XSControl"
+                },
+                {
+                    "expanded": "NETEAGLE",
+                    "value": "NETEAGLE"
+                },
+                {
+                    "expanded": "Agent.BTZ",
+                    "value": "Agent.BTZ"
+                },
+                {
+                    "description": "RAT bundle with standard VNC (to avoid/limit A/V detection).",
+                    "expanded": "Heseber BOT",
+                    "value": "Heseber BOT"
+                },
+                {
+                    "expanded": "Agent.dne",
+                    "value": "Agent.dne"
+                },
+                {
+                    "expanded": "Wipbot",
+                    "value": "Wipbot"
+                },
+                {
+                    "expanded": "Turla",
+                    "value": "Turla"
+                },
+                {
+                    "expanded": "Uroburos",
+                    "value": "Uroburos"
+                },
+                {
+                    "expanded": "Winexe",
+                    "value": "Winexe"
+                },
+                {
+                    "description": "RAT initialy identified in 2011 and still actively used.",
+                    "expanded": "Dark Comet",
+                    "value": "Dark Comet"
+                },
+                {
+                    "description": "RAT for Apple OS X platforms",
+                    "expanded": "AlienSpy",
+                    "value": "AlienSpy"
+                },
+                {
+                    "expanded": "Cadelspy",
+                    "value": "Cadelspy"
+                },
+                {
+                    "expanded": "CMStar",
+                    "value": "CMStar"
+                },
+                {
+                    "expanded": "DHS2015",
+                    "value": "DHS2015"
+                },
+                {
+                    "description": "Gh0st Rat is a well-known Chinese remote access trojan which was originally made by C.Rufus Security Team several years ago.",
+                    "expanded": "Gh0st Rat",
+                    "value": "Gh0st Rat"
+                },
+                {
+                    "description": "Fakem RAT makes their network traffic look like well-known protocols (e.g. Messenger traffic, HTML pages). ",
+                    "expanded": "Fakem RAT",
+                    "value": "Fakem RAT"
+                },
+                {
+                    "expanded": "MFC Huner",
+                    "value": "MFC Huner"
+                },
+                {
+                    "description": "Blackshades Remote Access Tool targets Microsoft Windows operating systems. Authors were arrested in 2012 and 2014.",
+                    "expanded": "Blackshades",
+                    "value": "Blackshades"
+                },
+                {
+                    "expanded": "CORESHELL",
+                    "value": "CORESHELL"
+                },
+                {
+                    "expanded": "CHOPSTICK",
+                    "value": "CHOPSTICK"
+                },
+                {
+                    "expanded": "SOURFACE",
+                    "value": "SOURFACE"
+                },
+                {
+                    "expanded": "OLDBAIT",
+                    "value": "OLDBAIT"
+                },
+                {
+                    "expanded": "Havex RAT",
+                    "value": "Havex RAT"
+                },
+                {
+                    "description": "RAT initially written in VB.",
+                    "expanded": "KjW0rm",
+                    "value": "KjW0rm"
+                },
+                {
+                    "expanded": "TinyTyphon",
+                    "value": "TinyTyphon"
+                },
+                {
+                    "expanded": "Badnews",
+                    "value": "Badnews"
+                },
+                {
+                    "expanded": "LURK",
+                    "value": "LURK"
+                },
+                {
+                    "expanded": "Oldrea",
+                    "value": "Oldrea"
+                },
+                {
+                    "expanded": "AmmyAdmin",
+                    "value": "AmmyAdmin"
+                },
+                {
+                    "expanded": "Matryoshka",
+                    "value": "Matryoshka"
+                },
+                {
+                    "expanded": "TinyZBot",
+                    "value": "TinyZBot"
+                },
+                {
+                    "expanded": "GHOLE",
+                    "value": "GHOLE"
+                },
+                {
+                    "expanded": "CWoolger",
+                    "value": "CWoolger"
+                },
+                {
+                    "expanded": "FireMalv",
+                    "value": "FireMalv"
+                },
+                {
+                    "expanded": "Regin",
+                    "value": "Regin"
+                },
+                {
+                    "expanded": "Duqu",
+                    "value": "Duqu"
+                },
+                {
+                    "expanded": "Flame",
+                    "value": "Flame"
+                },
+                {
+                    "expanded": "Stuxnet",
+                    "value": "Stuxnet"
+                },
+                {
+                    "expanded": "EquationLaser",
+                    "value": "EquationLaser"
+                },
+                {
+                    "expanded": "EquationDrug",
+                    "value": "EquationDrug"
+                },
+                {
+                    "expanded": "DoubleFantasy",
+                    "value": "DoubleFantasy"
+                },
+                {
+                    "expanded": "TripleFantasy",
+                    "value": "TripleFantasy"
+                },
+                {
+                    "expanded": "Fanny",
+                    "value": "Fanny"
+                },
+                {
+                    "expanded": "GrayFish",
+                    "value": "GrayFish"
+                },
+                {
+                    "expanded": "Babar",
+                    "value": "Babar"
+                },
+                {
+                    "expanded": "Bunny",
+                    "value": "Bunny"
+                },
+                {
+                    "expanded": "Casper",
+                    "value": "Casper"
+                },
+                {
+                    "expanded": "NBot",
+                    "value": "NBot"
+                },
+                {
+                    "expanded": "Tafacalou",
+                    "value": "Tafacalou"
+                },
+                {
+                    "expanded": "Tdrop",
+                    "value": "Tdrop"
+                },
+                {
+                    "expanded": "Troy",
+                    "value": "Troy"
+                },
+                {
+                    "expanded": "Tdrop2",
+                    "value": "Tdrop2"
+                },
+                {
+                    "expanded": "ZXShell",
+                    "value": "ZXShell"
+                },
+                {
+                    "expanded": "T9000",
+                    "value": "T9000"
+                },
+                {
+                    "expanded": "T5000",
+                    "value": "T5000"
+                },
+                {
+                    "expanded": "Taidoor",
+                    "value": "Taidoor"
+                },
+                {
+                    "expanded": "Swisyn",
+                    "value": "Swisyn"
+                },
+                {
+                    "expanded": "Rekaf",
+                    "value": "Rekaf"
+                },
+                {
+                    "expanded": "Scieron",
+                    "value": "Scieron"
+                },
+                {
+                    "expanded": "SkeletonKey",
+                    "value": "SkeletonKey"
+                },
+                {
+                    "expanded": "Skyipot",
+                    "value": "Skyipot"
+                },
+                {
+                    "expanded": "Spindest",
+                    "value": "Spindest"
+                },
+                {
+                    "expanded": "Preshin",
+                    "value": "Preshin"
+                },
+                {
+                    "expanded": "Rekaf",
+                    "value": "Rekaf"
+                },
+                {
+                    "expanded": "Oficla",
+                    "value": "Oficla"
+                },
+                {
+                    "expanded": "PCClient RAT",
+                    "value": "PCClient RAT"
+                },
+                {
+                    "expanded": "Plexor",
+                    "value": "Plexor"
+                },
+                {
+                    "expanded": "Mongall",
+                    "value": "Mongall"
+                },
+                {
+                    "expanded": "NeD Worm",
+                    "value": "NeD Worm"
+                },
+                {
+                    "expanded": "NewCT",
+                    "value": "NewCT"
+                },
+                {
+                    "expanded": "Nflog",
+                    "value": "Nflog"
+                },
+                {
+                    "expanded": "Janicab",
+                    "value": "Janicab"
+                },
+                {
+                    "expanded": "Jripbot",
+                    "value": "Jripbot"
+                },
+                {
+                    "expanded": "Jolob",
+                    "value": "Jolob"
+                },
+                {
+                    "expanded": "IsSpace",
+                    "value": "IsSpace"
+                },
+                {
+                    "expanded": "Hoardy",
+                    "value": "Hoardy"
+                },
+                {
+                    "expanded": "Htran",
+                    "value": "Htran"
+                },
+                {
+                    "expanded": "HTTPBrowser",
+                    "value": "HTTPBrowser"
+                },
+                {
+                    "expanded": "Disgufa",
+                    "value": "Disgufa"
+                },
+                {
+                    "expanded": "Elirks",
+                    "value": "Elirks"
+                },
+                {
+                    "expanded": "Snifula",
+                    "value": "Snifula"
+                },
+                {
+                    "expanded": "Aumlib",
+                    "value": "Aumlib"
+                },
+                {
+                    "expanded": "CTRat",
+                    "value": "CTRat"
+                },
+                {
+                    "expanded": "Emdivi",
+                    "value": "Emdivi"
+                },
+                {
+                    "expanded": "Etumbot",
+                    "value": "Etumbot"
+                },
+                {
+                    "expanded": "Fexel",
+                    "value": "Fexel"
+                },
+                {
+                    "expanded": "Fysbis",
+                    "value": "Fysbis"
+                },
+                {
+                    "expanded": "Hikit",
+                    "value": "Hikit"
+                },
+                {
+                    "expanded": "Hancitor",
+                    "value": "Hancitor"
+                },
+                {
+                    "expanded": "Ruckguv",
+                    "value": "Ruckguv"
+                },
+                {
+                    "expanded": "HerHer Trojan",
+                    "value": "HerHer Trojan"
+                },
+                {
+                    "expanded": "Helminth backdoor",
+                    "value": "Helminth backdoor"
+                },
+                {
+                    "expanded": "HDRoot",
+                    "value": "HDRoot"
+                },
+                {
+                    "expanded": "IRONGATE",
+                    "value": "IRONGATE"
+                },
+                {
+                    "expanded": "ShimRAT",
+                    "value": "ShimRAT"
+                },
+                {
+                    "expanded": "X-Agent",
+                    "value": "X-Agent"
+                },
+                {
+                    "expanded": "X-Tunnel",
+                    "value": "X-Tunnel"
+                },
+                {
+                    "expanded": "Foozer",
+                    "value": "Foozer"
+                },
+                {
+                    "expanded": "WinIDS",
+                    "value": "WinIDS"
+                },
+                {
+                    "expanded": "DownRange",
+                    "value": "DownRange"
+                },
+                {
+                    "expanded": "Mad Max",
+                    "value": "Mad Max"
+                },
+                {
+                    "description": "Crimson is malware used as part of a campaign known as Operation Transparent Tribe that targeted Indian diplomatic and military victims",
+                    "expanded": "Crimson",
+                    "value": "Crimson"
+                },
+                {
+                    "description": "Operation Groundbait based on our research into the Prikormka malware family. This includes detailed technical analysis of the Prikormka malware family and its spreading mechanisms, and a description of the most noteworthy attack campaigns.",
+                    "expanded": "Prikormka",
+                    "value": "Prikormka"
+                },
+                {
+                    "description": "This whitepaper details a malicious program we identify as NanHaiShu. Based on our analysis, the threat actor behind this malware targets government and private-sector organizations.",
+                    "expanded": "NanHaiShu",
+                    "value": "NanHaiShu"
+                },
+                {
+                    "description": "Umbreon (sharing the same name as the Pok\u00e9mon) targets Linux systems, including systems running both Intel and ARM processors, expanding the scope of this threat to include embedded devices as well.",
+                    "expanded": "Umbreon",
+                    "value": "Umbreon"
+                },
+                {
+                    "description": "Odinaff is typically deployed in the first stage of an attack, to gain a foothold onto the network, providing a persistent presence and the ability to install additional tools onto the target network. These additional tools bear the hallmarks of a sophisticated attacker which has plagued the financial industry since at least 2013\u2013Carbanak. This new wave of attacks has also used some infrastructure that has previously been used in Carbanak campaigns.",
+                    "expanded": "Odinaff",
+                    "value": "Odinaff"
+                },
+                {
+                    "description": "Unit 42 has observed a new version of Hworm (or Houdini) being used within multiple attacks. This blog outlines technical details of this new Hworm version and documents an attack campaign making use of the backdoor. Of the samples used in this attack, the first we observed were June 2016, while as-of publication we were still seeing attacks as recently as mid-October, suggesting that this is likely an active, ongoing campaign.",
+                    "expanded": "Hworm",
+                    "value": "Hworm"
+                },
+                {
+                    "description": "Backdoor.Dripion was custom developed, deployed in a highly targeted fashion, and used command and control servers disguised as antivirus company websites.",
+                    "expanded": "Backdoor.Dripion",
+                    "value": "Backdoor.Dripion"
+                },
+                {
+                    "description": "Adwind is a backdoor written purely in Java that targets system supporting the Java runtime environment. Commands that can be used, among other things, to display messages on the system, open URLs, update the malware, download/execute files, and download/load plugins. A significant amount of additional functionality can be provided through downloadable plugins, including such things as remote control options and shell command execution.",
+                    "expanded": "Adwind",
+                    "value": "Adwind"
+                },
+                {
+                    "description": "Angler Exploit Kit is a hacking tool that is produced to search for Java and Flash Player vulnerabilities on the attacked PC and use them with the aim to distribute malware infections. Angler Exploit Kit commonly checks to see if the PC it is proliferating to has Java or Flash.",
+                    "expanded": "Angler EK",
+                    "value": "Angler EK"
+                },
+                {
+                    "expanded": "Bedep",
+                    "value": "Bedep"
+                },
+                {
+                    "expanded": "Cromptui",
+                    "value": "Cromptui"
+                },
+                {
+                    "description": "CryptoWall is a new and highly destructive variant of ransomware. Ransomware is malicious software (malware) that infects your computer and holds hostage something of value to you in exchange for money. Older ransomware used to block access to computers. Newer ransomware, such as CryptoWall, takes your data hostage.",
+                    "expanded": "Cryptowall",
+                    "value": "Cryptowall"
+                },
+                {
+                    "expanded": "CTB-Locker",
+                    "value": "CTB-Locker"
+                },
+                {
+                    "description": "Dridex is a strain of banking malware that leverages macros in Microsoft Office to infect systems. Once a computer has been infected, Dridex attackers can steal banking credentials and other personal information on the system to gain access to the financial records of a user.",
+                    "expanded": "Dridex",
+                    "value": "Dridex"
+                },
+                {
+                    "expanded": "Fareit",
+                    "value": "Fareit"
+                },
+                {
+                    "expanded": "Gafgyt",
+                    "value": "Gafgyt"
+                },
+                {
+                    "description": "",
+                    "expanded": "Gamarue",
+                    "value": "Gamarue"
+                },
+                {
+                    "description": "Ransomware",
+                    "expanded": "Locky",
+                    "value": "Locky"
+                },
+                {
+                    "description": "The Necurs botnet is a distributor of many pieces of malware, most notably Locky.",
+                    "expanded": "Necurs",
+                    "value": "Necurs"
+                },
+                {
+                    "expanded": "Nuclear Pack",
+                    "value": "Nuclear Pack"
+                },
+                {
+                    "expanded": "Palevo",
+                    "value": "Palevo"
+                },
+                {
+                    "expanded": "Akbot",
+                    "value": "Akbot"
+                },
+                {
+                    "expanded": "Rig EK",
+                    "value": "Rig EK"
+                },
+                {
+                    "expanded": "Teslacrypt",
+                    "value": "Teslacrypt"
+                },
+                {
+                    "description": "Upatre is a Trojan downloader that is used to set up other threats on the victim's PC. Upatre has been used recently in several high profile Trojan attacks involving the Gameover Trojan. ",
+                    "expanded": "Upatre",
+                    "value": "Upatre"
+                },
+                {
+                    "description": "Vawtrak is an information stealing malware family that is primarily used to gain unauthorised access to bank accounts through online banking websites.",
+                    "expanded": "Vawtrak",
+                    "value": "Vawtrak"
+                }
+            ],
+            "predicate": "threat-actor-tool"
+        },
+        {
+            "entry": [
+                {
+                    "description": "PLA Unit 61398 (Chinese: 61398\u90e8\u961f, Pinyin: 61398 b\u00f9du\u00ec) is the Military Unit Cover Designator (MUCD)[1] of a People's Liberation Army advanced persistent threat unit that has been alleged to be a source of Chinese computer hacking attacks",
+                    "expanded": "Comment Crew",
+                    "value": "Comment Crew"
+                },
+                {
+                    "expanded": "Stalker Panda",
+                    "value": "Stalker Panda"
+                },
+                {
+                    "expanded": "Nitro",
+                    "value": "Nitro"
+                },
+                {
+                    "expanded": "Codoso",
+                    "value": "Codoso"
+                },
+                {
+                    "expanded": "Dust Storm",
+                    "value": "Dust Storm"
+                },
+                {
+                    "description": "Adversary targeting dissident groups in China and its surroundings.",
+                    "expanded": "Karma Panda",
+                    "value": "Karma Panda"
+                },
+                {
+                    "expanded": "Keyhole Panda",
+                    "value": "Keyhole Panda"
+                },
+                {
+                    "expanded": "Wet Panda",
+                    "value": "Wet Panda"
+                },
+                {
+                    "description": "Adversary group targeting telecommunication and technology organizations.",
+                    "expanded": "Foxy Panda",
+                    "value": "Foxy Panda"
+                },
+                {
+                    "expanded": "Predator Panda",
+                    "value": "Predator Panda"
+                },
+                {
+                    "expanded": "Union Panda",
+                    "value": "Union Panda"
+                },
+                {
+                    "expanded": "Spicy Panda",
+                    "value": "Spicy Panda"
+                },
+                {
+                    "expanded": "Eloquent Panda",
+                    "value": "Eloquent Panda"
+                },
+                {
+                    "description": "A China-based actor that targets foreign embassies to collect data on government, defence, and technology sectors.",
+                    "expanded": "Emissary Panda",
+                    "value": "Emissary Panda"
+                },
+                {
+                    "expanded": "Dizzy Panda",
+                    "value": "Dizzy Panda"
+                },
+                {
+                    "description": "The CrowdStrike Intelligence team has been tracking this particular unit since 2012, under the codename PUTTER PANDA, and has documented activity dating back to 2007. The report identifies Chen Ping, aka cpyy, and the primary location of Unit 61486. ",
+                    "expanded": "Putter Panda",
+                    "value": "Putter Panda"
+                },
+                {
+                    "expanded": "UPS",
+                    "value": "UPS"
+                },
+                {
+                    "expanded": "darkhotel",
+                    "value": "darkhotel"
+                },
+                {
+                    "description": "A group of China-based attackers, who conducted a number of spear phishing attacks in 2013.",
+                    "expanded": "IXESHE",
+                    "value": "IXESHE"
+                },
+                {
+                    "expanded": "APT 16",
+                    "value": "APT 16"
+                },
+                {
+                    "expanded": "Aurora Panda",
+                    "value": "Aurora Panda"
+                },
+                {
+                    "expanded": "Wekby",
+                    "value": "Wekby"
+                },
+                {
+                    "expanded": "Axiom",
+                    "value": "Axiom"
+                },
+                {
+                    "description": "Adversary group targeting financial, technology, non-profit organisations.",
+                    "expanded": "Shell Crew",
+                    "value": "Shell Crew"
+                },
+                {
+                    "expanded": "Naikon",
+                    "value": "Naikon"
+                },
+                {
+                    "expanded": "Lotus Blossom",
+                    "value": "Lotus Blossom"
+                },
+                {
+                    "expanded": "Lotus Panda",
+                    "value": "Lotus Panda"
+                },
+                {
+                    "expanded": "Hurricane Panda",
+                    "value": "Hurricane Panda"
+                },
+                {
+                    "expanded": "Emissary Panda",
+                    "value": "Emissary Panda"
+                },
+                {
+                    "expanded": "Stone Panda",
+                    "value": "Stone Panda"
+                },
+                {
+                    "expanded": "Nightshade Panda",
+                    "value": "Nightshade Panda"
+                },
+                {
+                    "expanded": "Hellsing",
+                    "value": "Hellsing"
+                },
+                {
+                    "expanded": "Night Dragon",
+                    "value": "Night Dragon"
+                },
+                {
+                    "expanded": "Mirage",
+                    "value": "Mirage"
+                },
+                {
+                    "expanded": "Anchor Panda",
+                    "value": "Anchor Panda"
+                },
+                {
+                    "expanded": "NetTraveler",
+                    "value": "NetTraveler"
+                },
+                {
+                    "expanded": "Ice Fog",
+                    "value": "Ice Fog"
+                },
+                {
+                    "expanded": "Pitty Panda",
+                    "value": "Pitty Panda"
+                },
+                {
+                    "expanded": "Roaming Tiger",
+                    "value": "Roaming Tiger"
+                },
+                {
+                    "expanded": "HiddenLynx",
+                    "value": "HiddenLynx"
+                },
+                {
+                    "expanded": "Beijing Group",
+                    "value": "Beijing Group"
+                },
+                {
+                    "expanded": "Radio Panda",
+                    "value": "Radio Panda"
+                },
+                {
+                    "expanded": "Dagger Panda",
+                    "value": "Dagger Panda"
+                },
+                {
+                    "expanded": "APT.3102",
+                    "value": "APT.3102"
+                },
+                {
+                    "expanded": "Samurai Panda",
+                    "value": "Samurai Panda"
+                },
+                {
+                    "expanded": "Impersonating Panda",
+                    "value": "Impersonating Panda"
+                },
+                {
+                    "expanded": "Violin Panda",
+                    "value": "Violin Panda"
+                },
+                {
+                    "description": "A group targeting dissident groups in China and at the boundaries.",
+                    "expanded": "Toxic Panda",
+                    "value": "Toxic Panda"
+                },
+                {
+                    "description": "China-based cyber threat group. It has previously used newsworthy events as lures to deliver malware and has primarily targeted organizations involved in financial, economic, and trade policy, typically using publicly available RATs such as PoisonIvy, as well as some non-public backdoors.",
+                    "expanded": "Temper Panda",
+                    "value": "Temper Panda"
+                },
+                {
+                    "expanded": "Pirate Panda",
+                    "value": "Pirate Panda"
+                },
+                {
+                    "expanded": "Flying Kitten",
+                    "value": "Flying Kitten"
+                },
+                {
+                    "expanded": "Cutting Kitten",
+                    "value": "Cutting Kitten"
+                },
+                {
+                    "expanded": "Charming Kitten",
+                    "value": "Charming Kitten"
+                },
+                {
+                    "description": "An established group of cyber attackers based in Iran, who carried on several campaigns in 2013, including a series of attacks targeting political dissidents and those supporting Iranian political opposition.",
+                    "expanded": "Magic Kitten",
+                    "value": "Magic Kitten"
+                },
+                {
+                    "expanded": "Cleaver",
+                    "value": "Cleaver"
+                },
+                {
+                    "expanded": "Sands Casino",
+                    "value": "Sands Casino"
+                },
+                {
+                    "description": "While tracking a suspected Iran-based threat group known as Threat Group-2889[1] (TG-2889), Dell SecureWorks Counter Threat Unit\u2122 (CTU) researchers uncovered a network of fake LinkedIn profiles. These convincing profiles form a self-referenced network of seemingly established LinkedIn users. CTU researchers assess with high confidence the purpose of this network is to target potential victims through social engineering. Most of the legitimate LinkedIn accounts associated with the fake accounts belong to individuals in the Middle East, and CTU researchers assess with medium confidence that these individuals are likely targets of TG-2889.",
+                    "expanded": "Threat Group-2889",
+                    "value": "Threat Group-2889"
+                },
+                {
+                    "expanded": "Rebel Jackal",
+                    "value": "Rebel Jackal"
+                },
+                {
+                    "expanded": "Viking Jackal",
+                    "value": "Viking Jackal"
+                },
+                {
+                    "description": "The Sofacy Group (also known as APT28, Pawn Storm, Fancy Bear and Sednit) is a cyber espionage group believed to have ties to the Russian government. Likely operating since 2007, the group is known to target government, military, and security organizations. It has been characterized as an advanced persistent threat.",
+                    "expanded": "Sofacy",
+                    "value": "Sofacy"
+                },
+                {
+                    "expanded": "APT 29",
+                    "value": "APT 29"
+                },
+                {
+                    "expanded": "Turla Group",
+                    "value": "Turla Group"
+                },
+                {
+                    "description": "A Russian group that collects intelligence on the energy industry.",
+                    "expanded": "Energetic Bear",
+                    "value": "Energetic Bear"
+                },
+                {
+                    "expanded": "Sandworm",
+                    "value": "Sandworm"
+                },
+                {
+                    "description": "Groups targeting financial organizations or people with significant financial assets.",
+                    "expanded": "Anunak",
+                    "value": "Anunak"
+                },
+                {
+                    "expanded": "TeamSpy Crew",
+                    "value": "TeamSpy Crew"
+                },
+                {
+                    "expanded": "BuhTrap",
+                    "value": "BuhTrap"
+                },
+                {
+                    "expanded": "Berserk Bear",
+                    "value": "Berserk Bear"
+                },
+                {
+                    "expanded": "Wolf Spider",
+                    "value": "Wolf Spider"
+                },
+                {
+                    "expanded": "Boulder Bear",
+                    "value": "Boulder Bear"
+                },
+                {
+                    "expanded": "Shark Spider",
+                    "value": "Shark Spider"
+                },
+                {
+                    "description": "Adversary targeting manufacturing and industrial organizations.",
+                    "expanded": "Union Spider",
+                    "value": "Union Spider"
+                },
+                {
+                    "expanded": "Silent Chollima",
+                    "value": "Silent Chollima"
+                },
+                {
+                    "expanded": "Lazarus Group",
+                    "value": "Lazarus Group"
+                },
+                {
+                    "expanded": "Viceroy Tiger",
+                    "value": "Viceroy Tiger"
+                },
+                {
+                    "expanded": "Pizzo Spider",
+                    "value": "Pizzo Spider"
+                },
+                {
+                    "expanded": "Corsair Jackal",
+                    "value": "Corsair Jackal"
+                },
+                {
+                    "expanded": "SNOWGLOBE",
+                    "value": "SNOWGLOBE"
+                },
+                {
+                    "description": "The Syrian Electronic Army (SEA) is a group of computer hackers which first surfaced online in 2011 to support the government of Syrian President Bashar al-Assad. Using spamming, website defacement, malware, phishing, and denial of service attacks, it has targeted political opposition groups, western news organizations, human rights groups and websites that are seemingly neutral to the Syrian conflict. It has also hacked government websites in the Middle East and Europe, as well as US defense contractors. As of 2011 the SEA has been *the first Arab country to have a public Internet Army hosted on its national networks to openly launch cyber attacks on its enemies*. The precise nature of SEA's relationship with the Syrian government has changed over time and is unclear",
+                    "expanded": "Deadeye Jackal",
+                    "value": "Deadeye Jackal"
+                },
+                {
+                    "description": "Group targeting Indian Army or related assets in India. Attribution to a Pakistani connection has been made by TrendMicro.",
+                    "expanded": "Operation C-Major",
+                    "value": "Operation C-Major"
+                },
+                {
+                    "description": "Group targeting Emirati journalists, activists, and dissidents.",
+                    "expanded": "Stealth Falcon",
+                    "value": "Stealth Falcon"
+                },
+                {
+                    "description": "ScarCruft is a relatively new APT group; victims have been observed in several countries, including Russia, Nepal, South Korea, China, India, Kuwait and Romania. The group has several ongoing operations utilizing multiple exploits \u2014 two for Adobe Flash and one for Microsoft Internet Explorer.",
+                    "expanded": "ScarCruft",
+                    "value": "ScarCruft"
+                },
+                {
+                    "description": "Bitdefender detected and blocked an ongoing cyber-espionage campaign against Romanian institutions and other foreign targets. The attacks started in 2014, with the latest reported occurrences in May of 2016. The APT, dubbed Pacifier by Bitdefender researchers, makes use of malicious .doc documents and .zip files distributed via spear phishing e-mail.",
+                    "expanded": "Pacifier APT",
+                    "value": "Pacifier APT"
+                },
+                {
+                    "description": "This group created a malware that takes over Android devices and generates $300,000 per month in fraudulent ad revenue.  The group effectively controls an arsenal of over 85 million mobile devices around the world. With the potential to sell access to these devices to the highest bidder",
+                    "expanded": "HummingBad",
+                    "value": "HummingBad"
+                },
+                {
+                    "description": "Dropping Elephant (also known as \u201cChinastrats\u201d and \u201cPatchwork\u201c) is a relatively new threat actor that is targeting a variety of high profile diplomatic and economic targets using a custom set of attack tools. Its victims are all involved with China\u2019s foreign relations in some way, and are generally caught through spear-phishing or watering hole attacks.",
+                    "expanded": "Dropping Elephant",
+                    "value": "Dropping Elephant"
+                },
+                {
+                    "description": "Proofpoint researchers recently uncovered evidence of an advanced persistent threat (APT) against Indian diplomatic and military resources. Our investigation began with malicious emails sent to Indian embassies in Saudi Arabia and Kazakstan but turned up connections to watering hole sites focused on Indian military personnel and designed to drop a remote access Trojan (RAT) with a variety of data exfiltration functions.",
+                    "expanded": "Operation Transparent Tribe",
+                    "value": "Operation Transparent Tribe"
+                },
+                {
+                    "description": "Scarlet Mimic is a threat group that has targeted minority rights activists. This group has not been directly linked to a government source, but the group's motivations appear to overlap with those of the Chinese government. While there is some overlap between IP addresses used by Scarlet Mimic and Putter Panda, it has not been concluded that the groups are the same.",
+                    "expanded": "Scarlet Mimic",
+                    "value": "Scarlet Mimic"
+                },
+                {
+                    "description": "Poseidon Group is a Portuguese-speaking threat group that has been active since at least 2005. The group has a history of using information exfiltrated from victims to blackmail victim companies into contracting the Poseidon Group as a security firm.",
+                    "expanded": "Poseidon Group",
+                    "value": "Poseidon Group"
+                },
+                {
+                    "description": "Threat group that has targeted Japanese organizations with phishing emails. Due to overlapping TTPs, including similar custom tools, DragonOK is thought to have a direct or indirect relationship with the threat group Moafee. 2223 It is known to use a variety of malware, including Sysget/HelloBridge, PlugX, PoisonIvy, FormerFirstRat, NFlog, and NewCT.",
+                    "expanded": "DragonOK",
+                    "value": "DragonOK"
+                },
+                {
+                    "description": "Chinese threat group that has extensively used strategic Web compromises to target victims.",
+                    "expanded": "Threat Group-3390",
+                    "value": "Threat Group-3390"
+                },
+                {
+                    "description": "ProjectSauron is the name for a top level modular cyber-espionage platform, designed to enable and manage long-term campaigns through stealthy survival mechanisms coupled with multiple exfiltration methods.  Technical details show how attackers learned from other extremely advanced actors in order to avoid repeating their mistakes. As such, all artifacts are customized per given target, reducing their value as indicators of compromise for any other victim.  Usually APT campaigns have a geographical nexus, aimed at extracting information within a specific region or from a given industry. That usually results in several infections in countries within that region, or in the targeted industry around the world. Interestingly, ProjectSauron seems to be dedicated to just a couple of countries, focused on collecting high value intelligence by compromising almost all key entities it could possibly reach within the target area.  The name, ProjectSauron reflects the fact that the code authors refer to \u2018Sauron\u2019 in the Lua scripts.",
+                    "expanded": "ProjectSauron",
+                    "value": "ProjectSauron"
+                },
+                {
+                    "expanded": "APT30",
+                    "value": "APT30"
+                },
+                {
+                    "description": "TA530, who we previously examined in relation to large-scale personalized phishing campaigns ",
+                    "expanded": "TA530",
+                    "value": "TA530"
+                },
+                {
+                    "description": "GCMAN is a threat group that focuses on targeting banks for the purpose of transferring money to e-currency services.",
+                    "expanded": "GCMAN",
+                    "value": "GCMAN"
+                },
+                {
+                    "description": "Suckfly is a China-based threat group that has been active since at least 2014",
+                    "expanded": "Suckfly",
+                    "value": "Suckfly"
+                },
+                {
+                    "description": "FIN is a group targeting financial assets including assets able to do financial transaction including PoS.",
+                    "expanded": "FIN6",
+                    "value": "FIN6"
+                },
+                {
+                    "description": "Libyan Scorpions is a malware operation in use since September 2015 and operated by a politically motivated group whose main objective is intelligence gathering, spying on influentials and political figures and operate an espionage campaign within Libya.",
+                    "expanded": "Libyan Scorpions",
+                    "value": "Libyan Scorpions"
+                },
+                {
+                    "expanded": "StrongPity",
+                    "value": "StrongPity"
+                },
+                {
+                    "expanded": "TeamXRat",
+                    "value": "TeamXRat"
+                }
+            ],
+            "predicate": "adversary-group"
+        }
+    ],
+    "version": 1
+}

--- a/tools/generator/misp-galaxy.py
+++ b/tools/generator/misp-galaxy.py
@@ -1,0 +1,58 @@
+import json
+import requests
+
+debug = False
+galaxy_url = 'https://raw.githubusercontent.com/MISP/misp-galaxy/master/elements/'
+elements = ['threat-actor-tools.json', 'adversary-groups.json']
+# elements = ['threat-actor-tools.json']
+
+taxonomy = {}
+taxonomy['namespace'] = 'misp-galaxy'
+taxonomy['description'] = 'Elements from the misp-galaxy as taxonomy (temporary measure)'
+taxonomy['version'] = 1  # FIXME - this should be incremented manually
+
+taxonomy['predicates'] = []
+taxonomy['values'] = []
+
+
+for element in elements:
+    g_element = requests.get(galaxy_url + element).json()
+
+    p_description = g_element['description']
+    if element.endswith('s.json'):
+        p_value = element[:-6]
+    elif element.endswith('-vocabulary.json'):
+        p_value = element[:-16]
+    else:
+        p_value = element
+
+    taxonomy['predicates'].append({'value': p_value, 'expanded': p_description})
+
+    t_value = {}
+    t_value['predicate'] = p_value
+    t_value['entry'] = []
+    for g_value in g_element['values']:
+        item = {}
+        item['value'] = g_value['value']
+        item['expanded'] = g_value['value']
+        if 'description' in g_value:
+            item['description'] = g_value['description']
+        t_value['entry'].append(item)
+
+        # if 'synonyms' in g_value:
+        #     for g_value_synonym in g_value['synonyms']:
+        #         item_s = dict(item)
+        #         item_s['value'] = g_value_synonym
+        #         item_s['expanded'] = g_value_synonym
+        #         t_value['entry'].append(item_s)
+    taxonomy['values'].append(t_value)
+
+file_out = '../../misp-galaxy/machinetag.json'
+with open(file_out, 'w') as f: 
+    f.write(json.dumps(taxonomy, sort_keys=True, indent=4, separators=(',', ': ')))
+print("JSON saved to "+ file_out)
+
+
+# t = Taxonomy(taxonomy)
+# with open('out-t.json', 'w') as f:
+#     f.write(json.dumps(t._json(), sort_keys=True, indent=4, separators=(',', ': ')))


### PR DESCRIPTION
This pull request bridges the future implementation of the galaxy with the taxonomies.
- a script to convert it automatically
- misp-galaxy namespace
- updated manifest file and machinetag.json


Limitations:
- version numbers are not taken into account when generating a new machinetag.json: the cause is that multiple galaxy elements have their own version number, but the taxonomy has only one. 
- synonyms are ignored: as discussed this was the preferred approach that would have the least complexity when the galaxy is integrated with MISP in a more advanced way. 

Please take the time to review and test with MISP before merging.