### PR TITLE
adding diamond model taxonomy

### DIFF
--- a/diamond-model/machinetag.json
+++ b/diamond-model/machinetag.json
@@ -1,0 +1,25 @@
+{
+  "namespace": "diamond-model",
+  "expanded": "Diamond Model for Intrusion Analysis",
+  "description": "The Diamond Model for Intrusion Analysis, a phase-based model developed by Lockheed Martin, aims to help categorise and identify the stage of an attack.",
+  "version": 1,
+  "predicates": [
+    {
+      "value": "Adversary",
+      "expanded": "An adversary is the actor/organization responsible for utilizing a capability against the victim to achieve their intent."
+    },
+    {
+      "value": "Capability",
+      "expanded": "The capability describes the tools and/or techniques of the adversary used in the event. It includes all means to affect the victim from the most manual “unsophisticated” methods (e.g., manual password guessing) to the most sophisticated automated techniques."
+    },
+    {
+      "value": "Infrastructure",
+      "expanded": "The infrastructure feature describes the physical and/or logical communication structures the adversary uses to deliver a capability, maintain control of capabilities (e.g., commandand-control/C2), and effect results from the victim (e.g., exfiltrate data). As with the other features, the infrastructure can be as specific or broad as necessary. Examples include: Internet Protocol (IP) addresses, domain names, e-mail addresses, Morse code flashes from a phone’s voice-mail light watched from across a street, USB devices found in a parking lot and inserted into a workstation, or the compromising emanations from hardware (e.g., Van Eck Phreaking) being collected by a nearby listening post."
+    },
+    {
+      "value": "Victim",
+      "expanded": "A victim is the target of the adversary and against whom vulnerabilities and exposures are exploited and capabilities used. A victim can be described in whichever way necessary and appropriate: organization, person, target email address, IP address, domain, etc. However, it is useful to define the victim persona and their assets separately as they serve different analytic functions. Victim personae are useful in non-technical analysis such as cyber-victimology and social-political centered approaches whereas victim assets are associated with common technical approaches such as vulnerability analysis.."
+    }
+  ],
+  "values": null
+}


### PR DESCRIPTION
Hi,

I quickly created the taxonomy describing the Diamond Model for Intrusion Analysis, definition of the fields are the official ones from the original paper
http://www.activeresponse.org/wp-content/uploads/2013/07/diamond.pdf

Not sure if possible to add this as source in the json as well.
Pasquale