### PR TITLE
Typo fix: replaces weaponiSation by weaponiZation

### DIFF
--- a/kill-chain/machinetag.json
+++ b/kill-chain/machinetag.json
@@ -2,7 +2,7 @@
   "namespace": "kill-chain",
   "expanded": "Cyber Kill Chain",
   "description": "The Cyber Kill Chain, a phase-based model developed by Lockheed Martin, aims to help categorise and identify the stage of an attack.",
-  "version": 1,
+  "version": 2,
   "predicates": [
     {
       "value": "Reconnaissance",

--- a/kill-chain/machinetag.json
+++ b/kill-chain/machinetag.json
@@ -9,7 +9,7 @@
       "expanded": "Research, identification and selection of targets, often represented as crawling Internet websites such as conference proceedings and mailing lists for email addresses, social relationships, or information on specific technologies."
     },
     {
-      "value": "Weaponisation",
+      "value": "Weaponization",
       "expanded": "Coupling a remote access trojan with an exploit into a deliverable payload, typically by means of an automated tool (weaponizer). Increasingly, client application data files such as Adobe Portable Document Format (PDF) or Microsoft Office documents serve as the weaponized deliverable."
     },
     {


### PR DESCRIPTION
The official term (see. http://www.lockheedmartin.com/us/what-we-do/aerospace-defense/cyber/cyber-kill-chain.html) relies on the American/Oxford spelling.