### PR TITLE
New items to analyst assessment, removal of analysis-related items

### DIFF
--- a/analyst-assessment/machinetag.json
+++ b/analyst-assessment/machinetag.json
@@ -18,6 +18,16 @@
       "value": "binary-reversing-experience",
       "expanded": "Reversing experience",
       "description": "The analyst experience in reversing expressed in years range in the field tagged. The year range is based on a standard 40-hour work week."
+    },
+    {
+      "value": "os",
+      "expanded": "Operating System",
+      "description": "Operating System that the analyst has experience with."
+    },
+    {
+      "value": "web",
+      "expanded": "Web applications-related skills",
+      "description": "Web application vulnerabilities and technique that the analyst has experience with."
     }
   ],
   "values": [
@@ -99,6 +109,52 @@
           "numerical_value": 5,
           "value": "more-than-20-years",
           "expanded": "More than 20 years"
+        }
+      ]
+    },
+    {
+      "predicate": "os",
+      "entry": [
+        {
+          "value": "windows",
+          "expanded": "Current Microsoft Windows system"
+        },
+        {
+          "value": "linux",
+          "expanded": "GNU/linux derivative OS"
+        },
+        {
+          "value": "ios",
+          "expanded": "Current IOS"
+        },
+        {
+          "value": "macos",
+          "expanded": "Current Apple OS"
+        },
+        {
+          "value": "android",
+          "expanded": "Current Android OS"
+        },
+        {
+          "value": "bsd",
+          "expanded": "BSD"
+        }
+      ]
+    },
+    {
+      "predicate": "web",
+      "entry": [
+        {
+          "value": "ipex",
+          "expanded": "Inter-protocol exploitations"
+        },
+        {
+          "value": "common",
+          "expanded": "Common vulnerabilities as SQL injections, CSRF, XSS, CSP bypasses, etc."
+        },
+        {
+          "value": "js-desobfuscation",
+          "expanded": "De-obfuscation of Javascript payloads"
         }
       ]
     }

--- a/analyst-assessment/machinetag.json
+++ b/analyst-assessment/machinetag.json
@@ -1,11 +1,7 @@
 {
   "namespace": "analyst-assessment",
   "expanded": "Analyst (Self) Assessment",
-  "refs": [
-    "http://www.foo.be/docs/intelligence/Tversky_Kahneman_1974.pdf",
-    "http://www.foo.be/docs/intelligence/PsychofIntelNew.pdf"
-  ],
-  "description": "A series of assessment predicates describing the analyst capabilities to perform analysis or making judgments under a certain level of uncertainty. These assessment can be assigned by the analyst him/herself or by another party evaluating the analyst.",
+  "description": "A series of assessment predicates describing the analyst capabilities to perform analysis. These assessment can be assigned by the analyst him/herself or by another party evaluating the analyst.",
   "version": 1,
   "predicates": [
     {
@@ -14,9 +10,14 @@
       "description": "The analyst experience expressed in years range in the field tagged. The year range is based on a standard 40-hour work week."
     },
     {
-      "value": "alternative-points-of-view-process",
-      "expanded": "Alternative points of view process",
-      "description": "A list of procedures or practices which describe alternative points of view to validate or rate an analysis. The list describes techniques or methods which could reinforce the estimative language in a human analysis and/or challenge the assumptions to reduce the potential bias of the analysis introduced by the analyst(s)."
+      "value": "binary-reversing-arch",
+      "expanded": "Reversing arch",
+      "description": "Architecture that the analyst has experience with."
+    },
+    {
+      "value": "binary-reversing-experience",
+      "expanded": "Reversing experience",
+      "description": "The analyst experience in reversing expressed in years range in the field tagged. The year range is based on a standard 40-hour work week."
     }
   ],
   "values": [
@@ -51,31 +52,53 @@
       ]
     },
     {
-      "predicate": "alternative-points-of-view-process",
+      "predicate": "binary-reversing-arch",
       "entry": [
         {
-          "value": "analytic-debates-within-the-organisation",
-          "expanded": "analytic debates within the organisation"
+          "value": "x86",
+          "expanded": "x86-32 & x86-64"
         },
         {
-          "value": "devils-advocates-methodology",
-          "expanded": "Devil's advocates methodlogy"
+          "value": "arm",
+          "expanded": "ARM & ARM-64"
         },
         {
-          "value": "competitive-analysis",
-          "expanded": "competitive analysis"
+          "value": "mips",
+          "expanded": "mips & mips-64"
         },
         {
-          "value": "interdisciplinary-brainstorming",
-          "expanded": "interdisciplinary brainstorming"
+          "value": "powerpc",
+          "expanded": "PowerPC"
+        }
+      ]
+    },
+    {
+      "predicate": "binary-reversing-experience",
+      "entry": [
+        {
+          "numerical_value": 1,
+          "value": "less-than-1-year",
+          "expanded": "Less than 1 year"
         },
         {
-          "value": "intra-office-peer-review",
-          "expanded": "intra-office peer review"
+          "numerical_value": 2,
+          "value": "between-1-and-5-years",
+          "expanded": "Between 1 and 5 years"
         },
         {
-          "value": "outside-expertise-review",
-          "expanded": "Outside expertise review"
+          "numerical_value": 3,
+          "value": "between-5-and-10-years",
+          "expanded": "Between 5 and 10 years"
+        },
+        {
+          "numerical_value": 4,
+          "value": "between-10-and-20-years",
+          "expanded": "Between 10 and 20 years"
+        },
+        {
+          "numerical_value": 5,
+          "value": "more-than-20-years",
+          "expanded": "More than 20 years"
         }
       ]
     }

--- a/analyst-assessment/machinetag.json
+++ b/analyst-assessment/machinetag.json
@@ -28,6 +28,11 @@
       "value": "web",
       "expanded": "Web applications-related skills",
       "description": "Web application vulnerabilities and technique that the analyst has experience with."
+    },
+    {
+      "value": "crypto-experience",
+      "expanded": "Experience",
+      "description": "The analyst experience related to cryptography expressed in years range in the field tagged."
     }
   ],
   "values": [
@@ -155,6 +160,36 @@
         {
           "value": "js-desobfuscation",
           "expanded": "De-obfuscation of Javascript payloads"
+        }
+      ]
+    },
+    {
+      "predicate": "crypto-experience",
+      "entry": [
+        {
+          "numerical_value": 1,
+          "value": "less-than-1-year",
+          "expanded": "Less than 1 year"
+        },
+        {
+          "numerical_value": 2,
+          "value": "between-1-and-5-years",
+          "expanded": "Between 1 and 5 years"
+        },
+        {
+          "numerical_value": 3,
+          "value": "between-5-and-10-years",
+          "expanded": "Between 5 and 10 years"
+        },
+        {
+          "numerical_value": 4,
+          "value": "between-10-and-20-years",
+          "expanded": "Between 10 and 20 years"
+        },
+        {
+          "numerical_value": 5,
+          "value": "more-than-20-years",
+          "expanded": "More than 20 years"
         }
       ]
     }

--- a/analyst-assessment/machinetag.json
+++ b/analyst-assessment/machinetag.json
@@ -30,6 +30,11 @@
       "description": "Web application vulnerabilities and technique that the analyst has experience with."
     },
     {
+      "value": "web-experience",
+      "expanded": "Experience",
+      "description": "The analyst experience expressed to web application security in years range in the field tagged."
+    },
+    {
       "value": "crypto-experience",
       "expanded": "Experience",
       "description": "The analyst experience related to cryptography expressed in years range in the field tagged."
@@ -160,6 +165,36 @@
         {
           "value": "js-desobfuscation",
           "expanded": "De-obfuscation of Javascript payloads"
+        }
+      ]
+    },
+    {
+      "predicate": "web-experience",
+      "entry": [
+        {
+          "numerical_value": 1,
+          "value": "less-than-1-year",
+          "expanded": "Less than 1 year"
+        },
+        {
+          "numerical_value": 2,
+          "value": "between-1-and-5-years",
+          "expanded": "Between 1 and 5 years"
+        },
+        {
+          "numerical_value": 3,
+          "value": "between-5-and-10-years",
+          "expanded": "Between 5 and 10 years"
+        },
+        {
+          "numerical_value": 4,
+          "value": "between-10-and-20-years",
+          "expanded": "Between 10 and 20 years"
+        },
+        {
+          "numerical_value": 5,
+          "value": "more-than-20-years",
+          "expanded": "More than 20 years"
         }
       ]
     },


### PR DESCRIPTION
Here is a modified version of the analyst assessment centred on the analyst's skills. I remove the part about the analysis because I think this should be put into a new taxonomy related to analyses.