### PR TITLE
Add automation-level predicate to misp taxonomy

### DIFF
--- a/misp/machinetag.json
+++ b/misp/machinetag.json
@@ -170,7 +170,7 @@
       "value": "tool"
     }
   ],
-  "version": 5,
+  "version": 6,
   "description": "MISP taxonomy to infer with MISP behavior or operation.",
   "expanded": "MISP",
   "namespace": "misp"

--- a/misp/machinetag.json
+++ b/misp/machinetag.json
@@ -156,6 +156,10 @@
       "value": "threat-level"
     },
     {
+      "expanded": "Automation level",
+      "value": "automation-level"
+    },
+    {
       "description": "Event with this tag should not be synced to other MISP instances",
       "expanded": "Should not sync",
       "value": "should-not-sync"

--- a/misp/machinetag.json
+++ b/misp/machinetag.json
@@ -75,7 +75,7 @@
       "entry": [
         {
           "expanded": "Generated automatically without human verification",
-          "value": "automatic",
+          "value": "unsupervised",
           "numerical_value": 100
         },
         {

--- a/misp/machinetag.json
+++ b/misp/machinetag.json
@@ -71,6 +71,26 @@
       ]
     },
     {
+      "predicate": "automation-level",
+      "entry": [
+        {
+          "expanded": "Generated automatically without human verification",
+          "value": "automatic",
+          "numerical_value": 100
+        },
+        {
+          "expanded": "Generated automatically but verified by a human",
+          "value": "reviewed",
+          "numerical_value": 50
+        },
+        {
+          "expanded": "Output of human analysis",
+          "value": "manual",
+          "numerical_value": 0
+        }
+      ]
+    },
+    {
       "predicate": "threat-level",
       "entry": [
         {


### PR DESCRIPTION
It is useful to label automatically and semi-automatically generated information accordingly as such. For this purpose, we propose the `misp:automation-level` predicate:

- `unsupervised`for data generated automatically without human verification
- `reviewed` for data generated automatically but verified by a human
- `manual` for data that is the output of human analysis

This change was co-designed with @h122015 and @amuehlem.