### PR TITLE
Bug fix

### DIFF
--- a/ifx-vetting/machinetag.json
+++ b/ifx-vetting/machinetag.json
@@ -1,0 +1,366 @@
+{
+    "namespace": "IFX",
+    "description": "The IFX taxonomy is used to categorise information (MISP events and attributes) to aid in the intelligence vetting process",
+    "version": 2,
+    "predicates": [
+        {
+            "value": "vetted",
+            "expanded": "state of the vetted intelligence"
+        },
+        {
+            "value": "score",
+            "expanded": "A numerical score added by a scoring algorithm of choice. The score can either be considered by an analyst or in combination with other tags be used for automatic processing of the data."
+        }
+    ],
+    "values": [
+        {
+            "predicate": "vetted",
+            "entry": [
+                {
+                    "value": "legit-but-compromised",
+                    "expanded": "The attribute describes something that is legitly used, but seems to be compromised by 3rd parties to be used for malicious activities. Consider this if blocking is your course of action."
+                },
+                {
+                    "value": "legit",
+                    "expanded": "The attribute describes something legitly used, that does not show signes of compromise or misuse."
+                },
+                {
+                    "value": "legit-uncertain",
+                    "expanded": "The attribute describes something where it is not 100% clear if it is used only legitly."
+                },
+                {
+                    "value": "malicious",
+                    "expanded": "The attribute describes something that is definitly used maliciously."
+                },
+                {
+                    "value": "malicious-uncertain",
+                    "expanded": "The attribute describes something that seems to be used maliciously, but there is no 100% proof."
+                },
+                {
+                    "value": "invalid",
+                    "expanded": "The attribute is invalid or wrong in respect to the situation described by the event."
+                },
+                {
+                    "value": "irrelevant",
+                    "expanded": "The attribute is irrelevant to your organization or CTI process."
+                },
+                {
+                    "value": "undetermined",
+                    "expanded": "The nature of the attribute cannot be further determined. Use this only as a last resort."
+                },
+                {
+                    "value": "fast-track",
+                    "expanded": "The attribute was not vetted but passed through for operational reasons. A result might be higher false-positive rates."
+                }
+            ]
+        },
+        {
+            "predicate": "score",
+            "entry": [
+                { 
+                    "value": "0"
+                },
+                { 
+                    "value": "1"
+                },
+                { 
+                    "value": "2"
+                },
+                { 
+                    "value": "3"
+                },
+                { 
+                    "value": "4"
+                },
+                { 
+                    "value": "5"
+                },
+                { 
+                    "value": "6"
+                },
+                { 
+                    "value": "7"
+                },
+                { 
+                    "value": "8"
+                },
+                { 
+                    "value": "9"
+                },
+                { 
+                    "value": "10"
+                },
+                { 
+                    "value": "11"
+                },
+                { 
+                    "value": "12"
+                },
+                { 
+                    "value": "13"
+                },
+                { 
+                    "value": "14"
+                },
+                { 
+                    "value": "15"
+                },
+                { 
+                    "value": "16"
+                },
+                { 
+                    "value": "17"
+                },
+                { 
+                    "value": "18"
+                },
+                { 
+                    "value": "19"
+                },
+                { 
+                    "value": "20"
+                },
+                { 
+                    "value": "21"
+                },
+                { 
+                    "value": "22"
+                },
+                { 
+                    "value": "23"
+                },
+                { 
+                    "value": "24"
+                },
+                { 
+                    "value": "25"
+                },
+                { 
+                    "value": "26"
+                },
+                { 
+                    "value": "27"
+                },
+                { 
+                    "value": "28"
+                },
+                { 
+                    "value": "29"
+                },
+                { 
+                    "value": "30"
+                },
+                { 
+                    "value": "31"
+                },
+                { 
+                    "value": "32"
+                },
+                { 
+                    "value": "33"
+                },
+                { 
+                    "value": "34"
+                },
+                { 
+                    "value": "35"
+                },
+                { 
+                    "value": "36"
+                },
+                { 
+                    "value": "37"
+                },
+                { 
+                    "value": "38"
+                },
+                { 
+                    "value": "39"
+                },
+                { 
+                    "value": "40"
+                },
+                { 
+                    "value": "41"
+                },
+                { 
+                    "value": "42"
+                },
+                { 
+                    "value": "43"
+                },
+                { 
+                    "value": "44"
+                },
+                { 
+                    "value": "45"
+                },
+                { 
+                    "value": "46"
+                },
+                { 
+                    "value": "47"
+                },
+                { 
+                    "value": "48"
+                },
+                { 
+                    "value": "49"
+                },
+                { 
+                    "value": "50"
+                },
+                { 
+                    "value": "51"
+                },
+                { 
+                    "value": "52"
+                },
+                { 
+                    "value": "53"
+                },
+                { 
+                    "value": "54"
+                },
+                { 
+                    "value": "55"
+                },
+                { 
+                    "value": "56"
+                },
+                { 
+                    "value": "57"
+                },
+                { 
+                    "value": "58"
+                },
+                { 
+                    "value": "59"
+                },
+                { 
+                    "value": "60"
+                },
+                { 
+                    "value": "61"
+                },
+                { 
+                    "value": "62"
+                },
+                { 
+                    "value": "63"
+                },
+                { 
+                    "value": "64"
+                },
+                { 
+                    "value": "65"
+                },
+                { 
+                    "value": "66"
+                },
+                { 
+                    "value": "67"
+                },
+                { 
+                    "value": "68"
+                },
+                { 
+                    "value": "69"
+                },
+                { 
+                    "value": "70"
+                },
+                { 
+                    "value": "71"
+                },
+                { 
+                    "value": "72"
+                },
+                { 
+                    "value": "73"
+                },
+                { 
+                    "value": "74"
+                },
+                { 
+                    "value": "75"
+                },
+                { 
+                    "value": "76"
+                },
+                { 
+                    "value": "77"
+                },
+                { 
+                    "value": "78"
+                },
+                { 
+                    "value": "79"
+                },
+                { 
+                    "value": "80"
+                },
+                { 
+                    "value": "81"
+                },
+                { 
+                    "value": "82"
+                },
+                { 
+                    "value": "83"
+                },
+                { 
+                    "value": "84"
+                },
+                { 
+                    "value": "85"
+                },
+                { 
+                    "value": "86"
+                },
+                { 
+                    "value": "87"
+                },
+                { 
+                    "value": "88"
+                },
+                { 
+                    "value": "89"
+                },
+                { 
+                    "value": "90"
+                },
+                { 
+                    "value": "91"
+                },
+                { 
+                    "value": "92"
+                },
+                { 
+                    "value": "93"
+                },
+                { 
+                    "value": "94"
+                },
+                { 
+                    "value": "95"
+                },
+                { 
+                    "value": "96"
+                },
+                { 
+                    "value": "97"
+                },
+                { 
+                    "value": "98"
+                },
+                { 
+                    "value": "99"
+                },
+                { 
+                    "value": "100"
+                }
+            ]
+        }
+    ]
+}

--- a/infoleak/machinetag.json
+++ b/infoleak/machinetag.json
@@ -49,6 +49,10 @@
           "expanded": "Credit card"
         },
         {
+          "value": "iban",
+          "expanded": "IBAN"
+        },
+        {
           "value": "mail",
           "expanded": "Mail"
         },
@@ -156,6 +160,10 @@
         {
           "value": "credit-card",
           "expanded": "Credit card"
+        },
+        {
+          "value": "iban",
+          "expanded": "IBAN"
         },
         {
           "value": "mail",


### PR DESCRIPTION
I fixed an issue which kept MISP from loading the taxonomy. 
Expand can't be empty if defined.