### PR TITLE
Update Ransomware Taxonomy

### DIFF
--- a/ransomware/machinetag.json
+++ b/ransomware/machinetag.json
@@ -2,7 +2,7 @@
   "namespace": "ransomware",
   "expanded": "ransomware types and elements",
   "description": "Ransomware is used to define ransomware types and the elements that compose them.",
-  "version": 2.1,
+  "version": 3,
   "refs": [
     "https://www.symantec.com/content/en/us/enterprise/media/security_response/whitepapers/the-evolution-of-ransomware.pdf",
     "https://docs.apwg.org/ecrimeresearch/2018/5357083.pdf",

--- a/ransomware/machinetag.json
+++ b/ransomware/machinetag.json
@@ -2,7 +2,7 @@
   "namespace": "ransomware",
   "expanded": "ransomware types and elements",
   "description": "Ransomware is used to define ransomware types and the elements that compose them.",
-  "version": 2,
+  "version": 2.1,
   "refs": [
     "https://www.symantec.com/content/en/us/enterprise/media/security_response/whitepapers/the-evolution-of-ransomware.pdf",
     "https://docs.apwg.org/ecrimeresearch/2018/5357083.pdf",
@@ -40,7 +40,7 @@
         },
         {
           "value": "locker-ransomware",
-          "expanded": "Locker eansomware, also called computer locker, denies access to the computer or device "
+          "expanded": "Locker ransomware, also called computer locker, denies access to the computer or device "
         },
         {
           "value": "crypto-ransomware",
@@ -54,6 +54,18 @@
         {
           "value": "ransomnote",
           "expanded": "A ransomnote is the message left by the attacker to threaten his victim and ask for ransom. It is usually seen as a text file or a picture set as background."
+        },
+        {
+          "value": "ransomware-appended-extension",
+          "expanded": "This is the extension added by the ransomware to the files."
+        },
+        {
+          "value": "ransomware-encrypted-extensions",
+          "expanded": "This is the list of extensions that will be encrypted by the ransomware. Beware to keep the order."
+        },
+        {
+          "value": "ransomware-excluded-extensions",
+          "expanded": "This is the list of extensions that will not be encrypted by the ransomware. Beware to keep the order."
         },
         {
           "value": "dropper",


### PR DESCRIPTION
**Date:** 2019-04-11
**Author:** SwitHak
**Purpose:** Add 3 meta tag to be able to give specification of extensions usage:  

1. ransomware-appended-extension
   -> This is the extension added by the ransomware to the files.
2. ransomware-encrypted-extensions",
   -> This is the list of extensions that will be encrypted by the ransomware. Beware to keep the order.
3. ransomware-excluded-extensions",
    -> This is the list of extensions that will not be encrypted by the ransomware. Beware to keep the order.

If I missed something, tell me through the PR or via Twitter: @SwitHak