### PR TITLE
chg: [infoleak] Added IP address tag value

### DIFF
--- a/infoleak/machinetag.json
+++ b/infoleak/machinetag.json
@@ -33,7 +33,7 @@
       "expanded": "Test"
     }
   ],
-  "version": 4,
+  "version": 5,
   "description": "A taxonomy describing information leaks and especially information classified as being potentially leaked. The taxonomy is based on the work by CIRCL on the AIL framework. The taxonomy aim is to be used at large to improve classification of leaked information.",
   "namespace": "infoleak",
   "values": [
@@ -51,6 +51,10 @@
         {
           "value": "iban",
           "expanded": "IBAN"
+        },
+        {
+          "value": "ip",
+          "expanded": "IP address"
         },
         {
           "value": "mail",
@@ -172,6 +176,10 @@
         {
           "value": "iban",
           "expanded": "IBAN"
+        },
+        {
+          "value": "ip",
+          "expanded": "IP address"
         },
         {
           "value": "mail",


### PR DESCRIPTION
What do you think? Should we add a distinction between ipv4 and ipv6? Would it make sense for mac address?