### PR TITLE
Adding IEP 2.0

### DIFF
--- a/iep2-policy-reference/machinetag.json
+++ b/iep2-policy-reference/machinetag.json
@@ -42,7 +42,7 @@
       "predicate": "iep_version",
       "entry": [
         {
-          "value": "2.0",
+          "value": 2.0,
           "expanded": "The IEP version value must be 2.0"
         }
       ]

--- a/iep2-policy-reference/machinetag.json
+++ b/iep2-policy-reference/machinetag.json
@@ -1,0 +1,51 @@
+{
+  "namespace": "iep2-policy-reference",
+  "description": "Forum of Incident Response and Security Teams (FIRST) Information Exchange Policy (IEP) framework v2.0 policy reference",
+  "version": 1,
+  "predicates": [
+    {
+      "value": "id_ref",
+      "expanded": "POLICY ID REFERENCE",
+      "description": "Refers to a unique IEP Policy ID to identify a specific IEP policy at a remote location."
+    },
+    {
+      "value": "url",
+      "expanded": "URL",
+      "description": "This is the remote URL specifying the IEP Policy File that contains the IEP Policy you wish to use."
+    },
+    {
+      "value": "iep_version",
+      "expanded": "IEP POLICY VERSION",
+      "description": "States the version of the IEP framework that has been used. Must be set to 2.0."
+    }
+  ],
+  "values": [
+    {
+      "predicate": "id_ref",
+      "entry": [
+        {
+          "value": "$text",
+          "expanded": "An id_ref value is required"
+        }
+      ]
+    },
+    {
+      "predicate": "url",
+      "entry": [
+        {
+          "value": "$text",
+          "expanded": "A URL value is required"
+        }
+      ]
+    },
+    {
+      "predicate": "iep_version",
+      "entry": [
+        {
+          "value": "2.0",
+          "expanded": "The IEP version value must be 2.0"
+        }
+      ]
+    }
+  ]
+}

--- a/iep2-policy/machinetag.json
+++ b/iep2-policy/machinetag.json
@@ -101,7 +101,7 @@
       "predicate": "iep_version",
       "entry": [
         {
-          "value": "2.0",
+          "value": 2.0,
           "expanded": "The IEP version value must be 2.0"
         }
       ]
@@ -111,7 +111,7 @@
       "entry": [
         {
           "value": "$text",
-          "expanded": "A start_date value is required"
+          "expanded": "A start_date value is required.  It must be a UTC date in RFC3339 format."
         }
       ]
     },
@@ -120,7 +120,7 @@
       "entry": [
         {
           "value": "$text",
-          "expanded": "An end_date value is required"
+          "expanded": "An end_date value is required. It must be a UTC date in RFC3339 format, or 'null'. null is used when the IEP policy never expires."
         }
       ]
     },
@@ -128,11 +128,11 @@
       "predicate": "encrypt_in_transit",
       "entry": [
         {
-          "value": "MUST",
+          "value": "must",
           "expanded": "Recipients MUST encrypt the information received when it is retransmitted or redistributed."
         },
         {
-          "value": "MAY",
+          "value": "may",
           "expanded": "Recipients MAY encrypt the information received when it is retransmitted or redistributed."
         }
       ]
@@ -141,23 +141,23 @@
       "predicate": "permitted_actions",
       "entry": [
         {
-          "value": "NONE",
+          "value": "none",
           "expanded": "Recipients MUST contact the Providers before acting upon the information received."
         },
         {
-          "value": "CONTACT FOR INSTRUCTION",
+          "value": "contact-for-instruction",
           "expanded": "Recipients MUST contact the Providers before acting upon the information received."
         },
         {
-          "value": "INTERNALLY VISIBLE ACTIONS",
+          "value": "internally-visible-actions",
           "expanded": "Recipients MAY conduct actions on the information received that are only visible on the Recipients internal networks and systems, and MUST NOT conduct actions that are visible outside of the Recipients networks and systems, or visible to third parties."
         },
         {
-          "value": "EXTERNALLY VISIBLE INDIRECT ACTIONS",
+          "value": "externally-visible-indirect-actions",
           "expanded": "Recipients MAY conduct indirect, or passive, actions on the information received that are externally visible and MUST NOT conduct direct, or active, actions."
         },
         {
-          "value": "EXTERNALLY VISIBLE DIRECT ACTIONS",
+          "value": "externally-visible-direct-actions",
           "expanded": "Recipients MAY conduct direct, or active, actions on the information received that are externally visible."
         }
       ]
@@ -166,11 +166,11 @@
       "predicate": "affected_party_notifications",
       "entry": [
         {
-          "value": "MAY",
+          "value": "may",
           "expanded": "Recipients MAY notify affected parties of a potential compromise or threat."
         },
         {
-          "value": "MUST NOT",
+          "value": "must-not",
           "expanded": "Recipients MUST NOT notify affected parties of potential compromise or threat."
         }
       ]
@@ -179,19 +179,19 @@
       "predicate": "tlp",
       "entry": [
         {
-          "value": "RED",
+          "value": "red",
           "expanded": "Personal for identified recipients only."
         },
         {
-          "value": "AMBER",
+          "value": "amber",
           "expanded": "Limited sharing on the basis of need-to-know."
         },
         {
-          "value": "GREEN",
+          "value": "green",
           "expanded": "Community wide sharing."
         },
         {
-          "value": "WHITE",
+          "value": "white",
           "expanded": "Unlimited sharing."
         }
       ]
@@ -200,15 +200,15 @@
       "predicate": "attribution",
       "entry": [
         {
-          "value": "MAY",
+          "value": "may",
           "expanded": "Recipients MAY attribute the Provider when redistributing the information received."
         },
         {
-          "value": "MUST",
+          "value": "must",
           "expanded": "Recipients MUST attribute the Provider when redistributing the information received."
         },
         {
-          "value": "MUST NOT",
+          "value": "must-not",
           "expanded": "Recipients MUST NOT attribute the Provider when redistributing the information received."
         }
       ]
@@ -217,11 +217,11 @@
       "predicate": "unmodified_resale",
       "entry": [
         {
-          "value": "MAY",
+          "value": "may",
           "expanded": "Recipients MAY resell the information received."
         },
         {
-          "value": "MUST NOT",
+          "value": "must-not",
           "expanded": "Recipients MUST NOT resell the information received unmodified or in a semantically equivalent format."
         }
       ]
@@ -231,7 +231,7 @@
       "entry": [
         {
           "value": "$text",
-          "expanded": "An external_reference value is a link to an external "
+          "expanded": "An external_reference value is a URL that contains information relevant for this IEP policy. The URL MUST adhere to RFC3986."
         }
       ]
     }

--- a/iep2-policy/machinetag.json
+++ b/iep2-policy/machinetag.json
@@ -1,0 +1,239 @@
+{
+  "namespace": "iep2-policy",
+  "description": "Forum of Incident Response and Security Teams (FIRST) Information Exchange Policy (IEP) framework v2.0 policy",
+  "version": 1,
+  "predicates": [
+    {
+      "value": "id",
+      "expanded": "POLICY ID",
+      "description": "Provides a unique ID to identify a specific IEP policy."
+    },
+    {
+      "value": "name",
+      "expanded": "POLICY NAME",
+      "description": "This statement can be used to provide a name for an IEP policy."
+    },
+    {
+      "value": "description",
+      "expanded": "POLICY DESCRIPTION",
+      "description": "This statement can be used to provide more details as a background for an IEP policy."
+    },
+    {
+      "value": "iep_version",
+      "expanded": "IEP POLICY VERSION",
+      "description": "States the version of the IEP framework that has been used. Must be set to 2.0."
+    },
+    {
+      "value": "start_date",
+      "expanded": "POLICY START DATE",
+      "description": "States the UTC date that the IEP is effective from."
+    },
+    {
+      "value": "end_date",
+      "expanded": "POLICY END DATE",
+      "description": "States the UTC date that the IEP is effective until."
+    },
+    {
+      "value": "encrypt_in_transit",
+      "expanded": "ENCRYPT IN TRANSIT",
+      "description": "States whether the received information has to be encrypted when it is retransmitted by the recipient."
+    },
+    {
+      "value": "permitted_actions",
+      "expanded": "PERMITTED ACTIONS",
+      "description": "States the permitted actions that Recipients can take upon information received."
+    },
+    {
+      "value": "affected_party_notifications",
+      "expanded": "AFFECTED PARTY NOTIFICATIONS",
+      "description": "Recipients are permitted notify affected third parties of a potential compromise or threat."
+    },
+    {
+      "value": "tlp",
+      "expanded": "TRAFFIC LIGHT PROTOCOL",
+      "description": "Recipients are permitted to redistribute the information received within the redistribution scope as defined by the enumerations."
+    },
+    {
+      "value": "attribution",
+      "expanded": "ATTRIBUTION",
+      "description": "Recipients could be required to attribute or anonymize the Provider when redistributing the information received."
+    },
+    {
+      "value": "unmodified_resale",
+      "expanded": "UNMODIFIED RESALE",
+      "description": "States whether the recipient MAY or MUST NOT resell the information received unmodified or in a semantically equivalent format."
+    },
+    {
+      "value": "external_reference",
+      "expanded": "EXTERNAL REFERENCE",
+      "description": "This statement can be used to convey a description or reference to any applicable licenses, agreements, or conditions between the producer and receiver."
+    }
+  ],
+  "values": [
+    {
+      "predicate": "id",
+      "entry": [
+        {
+          "value": "$text",
+          "expanded": "An id value is required"
+        }
+      ]
+    },
+    {
+      "predicate": "name",
+      "entry": [
+        {
+          "value": "$text",
+          "expanded": "A name value is required"
+        }
+      ]
+    },
+    {
+      "predicate": "description",
+      "entry": [
+        {
+          "value": "$text",
+          "expanded": "A description value is required"
+        }
+      ]
+    },
+    {
+      "predicate": "iep_version",
+      "entry": [
+        {
+          "value": "2.0",
+          "expanded": "The IEP version value must be 2.0"
+        }
+      ]
+    },
+    {
+      "predicate": "start_date",
+      "entry": [
+        {
+          "value": "$text",
+          "expanded": "A start_date value is required"
+        }
+      ]
+    },
+    {
+      "predicate": "end_date",
+      "entry": [
+        {
+          "value": "$text",
+          "expanded": "An end_date value is required"
+        }
+      ]
+    },
+    {
+      "predicate": "encrypt_in_transit",
+      "entry": [
+        {
+          "value": "MUST",
+          "expanded": "Recipients MUST encrypt the information received when it is retransmitted or redistributed."
+        },
+        {
+          "value": "MAY",
+          "expanded": "Recipients MAY encrypt the information received when it is retransmitted or redistributed."
+        }
+      ]
+    },
+    {
+      "predicate": "permitted_actions",
+      "entry": [
+        {
+          "value": "NONE",
+          "expanded": "Recipients MUST contact the Providers before acting upon the information received."
+        },
+        {
+          "value": "CONTACT FOR INSTRUCTION",
+          "expanded": "Recipients MUST contact the Providers before acting upon the information received."
+        },
+        {
+          "value": "INTERNALLY VISIBLE ACTIONS",
+          "expanded": "Recipients MAY conduct actions on the information received that are only visible on the Recipients internal networks and systems, and MUST NOT conduct actions that are visible outside of the Recipients networks and systems, or visible to third parties."
+        },
+        {
+          "value": "EXTERNALLY VISIBLE INDIRECT ACTIONS",
+          "expanded": "Recipients MAY conduct indirect, or passive, actions on the information received that are externally visible and MUST NOT conduct direct, or active, actions."
+        },
+        {
+          "value": "EXTERNALLY VISIBLE DIRECT ACTIONS",
+          "expanded": "Recipients MAY conduct direct, or active, actions on the information received that are externally visible."
+        }
+      ]
+    },
+    {
+      "predicate": "affected_party_notifications",
+      "entry": [
+        {
+          "value": "MAY",
+          "expanded": "Recipients MAY notify affected parties of a potential compromise or threat."
+        },
+        {
+          "value": "MUST NOT",
+          "expanded": "Recipients MUST NOT notify affected parties of potential compromise or threat."
+        }
+      ]
+    },
+    {
+      "predicate": "tlp",
+      "entry": [
+        {
+          "value": "RED",
+          "expanded": "Personal for identified recipients only."
+        },
+        {
+          "value": "AMBER",
+          "expanded": "Limited sharing on the basis of need-to-know."
+        },
+        {
+          "value": "GREEN",
+          "expanded": "Community wide sharing."
+        },
+        {
+          "value": "WHITE",
+          "expanded": "Unlimited sharing."
+        }
+      ]
+    },
+    {
+      "predicate": "attribution",
+      "entry": [
+        {
+          "value": "MAY",
+          "expanded": "Recipients MAY attribute the Provider when redistributing the information received."
+        },
+        {
+          "value": "MUST",
+          "expanded": "Recipients MUST attribute the Provider when redistributing the information received."
+        },
+        {
+          "value": "MUST NOT",
+          "expanded": "Recipients MUST NOT attribute the Provider when redistributing the information received."
+        }
+      ]
+    },
+    {
+      "predicate": "unmodified_resale",
+      "entry": [
+        {
+          "value": "MAY",
+          "expanded": "Recipients MAY resell the information received."
+        },
+        {
+          "value": "MUST NOT",
+          "expanded": "Recipients MUST NOT resell the information received unmodified or in a semantically equivalent format."
+        }
+      ]
+    },
+    {
+      "predicate": "external_reference",
+      "entry": [
+        {
+          "value": "$text",
+          "expanded": "An external_reference value is a link to an external "
+        }
+      ]
+    }
+  ]
+}

--- a/iep2-policy/machinetag.json
+++ b/iep2-policy/machinetag.json
@@ -1,6 +1,6 @@
 {
   "namespace": "iep2-policy",
-  "description": "Forum of Incident Response and Security Teams (FIRST) Information Exchange Policy (IEP) framework v2.0 policy",
+  "description": "Forum of Incident Response and Security Teams (FIRST) Information Exchange Policy (IEP) v2.0 Policy",
   "version": 1,
   "predicates": [
     {

--- a/iep2-reference/machinetag.json
+++ b/iep2-reference/machinetag.json
@@ -1,6 +1,6 @@
 {
-  "namespace": "iep2-policy-reference",
-  "description": "Forum of Incident Response and Security Teams (FIRST) Information Exchange Policy (IEP) framework v2.0 policy reference",
+  "namespace": "iep2-reference",
+  "description": "Forum of Incident Response and Security Teams (FIRST) Information Exchange Policy (IEP) v2.0 Reference",
   "version": 1,
   "predicates": [
     {


### PR DESCRIPTION
Hi,

I'm one of the IEP co-chairs, and we've just had IEP 2.0 approved by the FIRST board. We're in the process of getting IEP 2.0 website created (it will live at https://www.first.org/iep/), but it's not quite online yet.

As MISP had an IEP 1.0 implementation we wanted to help out the community and do one for IEP 2.0 as well. IEP 2.0 has two objects, the IEP Policy object and the IEP 2.0 Policy Reference object, and as such this pull request contains those two objects as well. 

There is one bit I'd like special review on, and that is the fact that I've used a JSON number for the iep_version tag. The reason is that IEP 2.0 specifies the iep_version must be a JSON number. We'd like to check that this won't break MISP... as we're not sure if MISP will handle numerical values in the tags. machinetag.py seems happy to convert this to text, but we'd just like confirmation that this won't break MISP.

I've tested using machinetag.py and have the following results: 
PS E:\vscode-projects\misp-taxonomies\tools> python.exe .\machinetag.py -n iep2-policy
iep2-policy:id="$text"
iep2-policy:name="$text"
iep2-policy:description="$text"
iep2-policy:iep_version="2.0"
iep2-policy:start_date="$text"
iep2-policy:end_date="$text"
iep2-policy:encrypt_in_transit="must"
iep2-policy:encrypt_in_transit="may"
iep2-policy:permitted_actions="none"
iep2-policy:permitted_actions="contact-for-instruction"
iep2-policy:permitted_actions="internally-visible-actions"
iep2-policy:permitted_actions="externally-visible-indirect-actions"
iep2-policy:permitted_actions="externally-visible-direct-actions"
iep2-policy:affected_party_notifications="may"
iep2-policy:affected_party_notifications="must-not"
iep2-policy:tlp="red"
iep2-policy:tlp="amber"
iep2-policy:tlp="green"
iep2-policy:tlp="white"
iep2-policy:attribution="may"
iep2-policy:attribution="must"
iep2-policy:attribution="must-not"
iep2-policy:unmodified_resale="may"
iep2-policy:unmodified_resale="must-not"
iep2-policy:external_reference="$text"
PS E:\vscode-projects\misp-taxonomies\tools> python.exe .\machinetag.py -n iep2-reference
iep2-reference:id_ref="$text"
iep2-reference:url="$text"
iep2-reference:iep_version="2.0"

Thanks
Terry MacDonald
FIRST IEP-SIG Co-chair