### PR TITLE
Adding the Trust Taxonomy

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -554,6 +554,11 @@
       "version": 1
     },
     {
+      "description": "Indicators of Trust provide insight about data on what can be trusted and known as a good actor. Similar to a whitelist but on steroids, reusing features one would use with Indicators of Compromise, but to filter out what is known to be good.",
+      "name": "trust",
+      "version": 1
+    },
+    {
       "description": "The Use Case Applicability categories reflect standard resolution categories, to clearly display alerting rule configuration problems.",
       "name": "use-case-applicability",
       "version": 1
@@ -575,5 +580,5 @@
     }
   ],
   "url": "https://raw.githubusercontent.com/MISP/misp-taxonomies/master/",
-  "version": "20200324"
+  "version": "20200401"
 }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ bfuscation techniques. This taxonomy lists all the known or official packer used
 - [The Permissible Actions Protocol - or short: PAP - was designed to indicate how the received information can be used.](./PAP)
 - [Targeted Threat Index is a metric for assigning an overall threat ranking score to email messages that deliver malware to a victim’s computer.](./targeted-threat-index)
 - [TLP - Traffic Light Protocol](./tlp)
+- [Trust - Indicators of Trust](./trust)
 - [Type](./type)
 - [Vocabulaire des probabilités estimatives](./vocabulaire-des-probabilites-estimatives)
 - Vocabulary for Event Recording and Incident Sharing [VERIS](./veris)
@@ -179,6 +180,10 @@ The Permissible Actions Protocol - or short: PAP - was designed to indicate how 
 ### [TLP - Traffic Light Protocol](./tlp)
 
 The Traffic Light Protocol - or short: TLP - was designed with the objective to create a favorable classification scheme for sharing sensitive information while keeping the control over its distribution at the same time.
+
+### [Trust - Indicators of Trust](./trust)
+
+Indicators of Trust provide insight about data on what can be trusted and known as a good actor. Similar to a whitelist but on steroids, reusing features one would use with Indicators of Compromise, but to filter out what is known to be good.
 
 ### Vocabulary for Event Recording and Incident Sharing [VERIS](./veris)
 

--- a/trust/machinetag.json
+++ b/trust/machinetag.json
@@ -1,98 +1,52 @@
 {
-    "predicates": [
-	{
-	    "colour": "#2657ff",
-	    "description": "This domain is known to be good",
-	    "expanded": "A domain, the human name given to a host can be trusted",
-	    "value": "domain"
-	},
-	{
-	    "colour": "#e8c90e",
-	    "description": "This IP is known to be good",
-	    "expanded": "This IP address can be trusted",
-	    "value": "ip"
-	},
-	{
-	    "colour": "#0E40E8",
-	    "description": "This SHA256 Hash is trust worthy",
-	    "expanded": "This SHA256 Hash can be trusted",
-	    "value": "sha256"
-	},
-	{
-	    "colour": "#0E40E8",
-	    "description": "This SHA384 Hash is trust worthy",
-	    "expanded": "This SHA384 Hash can be trusted",
-	    "value": "sha384"
-	},
-	{
-	    "colour": "#0E40E8",
-	    "description": "This SHA512 Hash is trust worthy",
-	    "expanded": "This SHA512 Hash can be trusted",
-	    "value": "sha512"
-	},
-	{
-	    "colour": "#00BD25",
-	    "description": "This URI is trust worthy",
-	    "expanded": "This URI can be trusted",
-	    "value": "uri"
-	},
-	{
-	    "colour": "#00BD25",
-	    "description": "This URL is trust worthy",
-	    "expanded": "This URL can be trusted",
-	    "value": "url"
-	},
-	{
-	    "colour": "#9D9D9D",
-	    "description": "This email is trust worthy",
-	    "expanded": "This email can be trusted",
-	    "value": "email"
-	}
-    ],
-  "values": [
+  "predicates": [
     {
-      "predicate": "confidence",
-      "entry": [
-        {
-          "value": "High",
-          "expanded": "High confidence"
-        },
-        {
-          "value": "Low",
-          "expanded": "Low confidence"
-        },
-        {
-          "value": "Medium",
-          "expanded": "Medium confidence"
-        }
-      ]
-    }
-  ],
-  "values": [
+      "colour": "#2657ff",
+      "description": "This domain is known to be good",
+      "expanded": "A domain, the human name given to a host can be trusted",
+      "value": "domain"
+    },
     {
-      "predicate": "periodicity",
-      "entry": [
-        {
-          "value": "hourly",
-          "expanded": ""
-        },
-        {
-          "value": "daily",
-          "expanded": ""
-        },
-        {
-          "value": "weekly",
-          "expanded": ""
-        },
-        {
-          "value": "monthly",
-          "expanded": ""
-        },
-        {
-          "value": "yearly",
-          "expanded": ""
-        }
-      ]
+      "colour": "#e8c90e",
+      "description": "This IP is known to be good",
+      "expanded": "This IP address can be trusted",
+      "value": "ip"
+    },
+    {
+      "colour": "#0E40E8",
+      "description": "This SHA256 Hash is trust worthy",
+      "expanded": "This SHA256 Hash can be trusted",
+      "value": "sha256"
+    },
+    {
+      "colour": "#0E40E8",
+      "description": "This SHA384 Hash is trust worthy",
+      "expanded": "This SHA384 Hash can be trusted",
+      "value": "sha384"
+    },
+    {
+      "colour": "#0E40E8",
+      "description": "This SHA512 Hash is trust worthy",
+      "expanded": "This SHA512 Hash can be trusted",
+      "value": "sha512"
+    },
+    {
+      "colour": "#00BD25",
+      "description": "This URI is trust worthy",
+      "expanded": "This URI can be trusted",
+      "value": "uri"
+    },
+    {
+      "colour": "#00BD25",
+      "description": "This URL is trust worthy",
+      "expanded": "This URL can be trusted",
+      "value": "url"
+    },
+    {
+      "colour": "#9D9D9D",
+      "description": "This email is trust worthy",
+      "expanded": "This email can be trusted",
+      "value": "email"
     }
   ],
   "values": [
@@ -118,12 +72,12 @@
       ]
     }
   ],
-    "refs": [
-	"https://trust.fyi"
-    ],
-    "version": 1,
-    "description": "Indicators of Trust provide insight about data on what can be trusted and known as a good actor. Similar to a whitelist but on steroids, reusing features one would use with Indicators of Compromise, but to filter out what is known to be good.",
-    "expanded": "Indicators of Trust",
-    "namespace": "trust",
-    "exclusive": true
+  "refs": [
+    "https://trust.fyi"
+  ],
+  "version": 1,
+  "description": "Indicators of Trust provide insight about data on what can be trusted and known as a good actor. Similar to a whitelist but on steroids, reusing features one would use with Indicators of Compromise, but to filter out what is known to be good.",
+  "expanded": "Indicators of Trust",
+  "namespace": "trust",
+  "exclusive": true
 }

--- a/trust/machinetag.json
+++ b/trust/machinetag.json
@@ -55,19 +55,19 @@
       "entry": [
         {
           "value": "low",
-          "expanded": ""
+          "expanded": "Low Change"
         },
         {
           "value": "medium",
-          "expanded": ""
+          "expanded": "Medium Change"
         },
         {
           "value": "high",
-          "expanded": ""
+          "expanded": "High Change"
         },
         {
           "value": "unknown",
-          "expanded": ""
+          "expanded": "Unknown Change Likelihood"
         }
       ]
     }

--- a/trust/machinetag.json
+++ b/trust/machinetag.json
@@ -1,0 +1,129 @@
+{
+    "predicates": [
+	{
+	    "colour": "#2657ff",
+	    "description": "This domain is known to be good",
+	    "expanded": "A domain, the human name given to a host can be trusted",
+	    "value": "domain"
+	},
+	{
+	    "colour": "#e8c90e",
+	    "description": "This IP is known to be good",
+	    "expanded": "This IP address can be trusted",
+	    "value": "ip"
+	},
+	{
+	    "colour": "#0E40E8",
+	    "description": "This SHA256 Hash is trust worthy",
+	    "expanded": "This SHA256 Hash can be trusted",
+	    "value": "sha256"
+	},
+	{
+	    "colour": "#0E40E8",
+	    "description": "This SHA384 Hash is trust worthy",
+	    "expanded": "This SHA384 Hash can be trusted",
+	    "value": "sha384"
+	},
+	{
+	    "colour": "#0E40E8",
+	    "description": "This SHA512 Hash is trust worthy",
+	    "expanded": "This SHA512 Hash can be trusted",
+	    "value": "sha512"
+	},
+	{
+	    "colour": "#00BD25",
+	    "description": "This URI is trust worthy",
+	    "expanded": "This URI can be trusted",
+	    "value": "uri"
+	},
+	{
+	    "colour": "#00BD25",
+	    "description": "This URL is trust worthy",
+	    "expanded": "This URL can be trusted",
+	    "value": "url"
+	},
+	{
+	    "colour": "#9D9D9D",
+	    "description": "This email is trust worthy",
+	    "expanded": "This email can be trusted",
+	    "value": "email"
+	}
+    ],
+  "values": [
+    {
+      "predicate": "confidence",
+      "entry": [
+        {
+          "value": "High",
+          "expanded": "High confidence"
+        },
+        {
+          "value": "Low",
+          "expanded": "Low confidence"
+        },
+        {
+          "value": "Medium",
+          "expanded": "Medium confidence"
+        }
+      ]
+    }
+  ],
+  "values": [
+    {
+      "predicate": "periodicity",
+      "entry": [
+        {
+          "value": "hourly",
+          "expanded": ""
+        },
+        {
+          "value": "daily",
+          "expanded": ""
+        },
+        {
+          "value": "weekly",
+          "expanded": ""
+        },
+        {
+          "value": "monthly",
+          "expanded": ""
+        },
+        {
+          "value": "yearly",
+          "expanded": ""
+        }
+      ]
+    }
+  ],
+  "values": [
+    {
+      "predicate": "change-likelihood",
+      "entry": [
+        {
+          "value": "low",
+          "expanded": ""
+        },
+        {
+          "value": "medium",
+          "expanded": ""
+        },
+        {
+          "value": "high",
+          "expanded": ""
+        },
+        {
+          "value": "unknown",
+          "expanded": ""
+        }
+      ]
+    }
+  ],
+    "refs": [
+	"https://trust.fyi"
+    ],
+    "version": 1,
+    "description": "Indicators of Trust provide insight about data on what can be trusted and known as a good actor. Similar to a whitelist but on steroids, reusing features one would use with Indicators of Compromise, but to filter out what is known to be good.",
+    "expanded": "Indicators of Trust",
+    "namespace": "trust",
+    "exclusive": true
+}


### PR DESCRIPTION
It is used to describe what is known to be good, instead of the bad stuff.

This goes along what I described during my talk at CanSecWest: http://io.libio.so/stricaud-cansec2020.pdf 

Instead of using attributes to search for the bad, we use attributes to filter out the good things, similar to a whitelist, except it leverages all MISP features.