### PR TITLE
Trust Taxonomy

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -544,6 +544,11 @@
       "version": 5
     },
     {
+      "description": "The Indicator of Trust provides insight about data on what can be trusted and known as a good actor. Similar to a whitelist but on steroids, reusing features one would use with Indicators of Compromise, but to filter out what is known to be good.",
+      "name": "trust",
+      "version": 1
+    },
+    {
       "description": "Taxonomy to describe Tor network infrastructure",
       "name": "tor",
       "version": 1

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ bfuscation techniques. This taxonomy lists all the known or official packer used
 - [The Permissible Actions Protocol - or short: PAP - was designed to indicate how the received information can be used.](./PAP)
 - [Targeted Threat Index is a metric for assigning an overall threat ranking score to email messages that deliver malware to a victim’s computer.](./targeted-threat-index)
 - [TLP - Traffic Light Protocol](./tlp)
+- [Trust - Indicators of Trust](./trust)
 - [Type](./type)
 - [Vocabulaire des probabilités estimatives](./vocabulaire-des-probabilites-estimatives)
 - Vocabulary for Event Recording and Incident Sharing [VERIS](./veris)
@@ -179,6 +180,10 @@ The Permissible Actions Protocol - or short: PAP - was designed to indicate how 
 ### [TLP - Traffic Light Protocol](./tlp)
 
 The Traffic Light Protocol - or short: TLP - was designed with the objective to create a favorable classification scheme for sharing sensitive information while keeping the control over its distribution at the same time.
+
+### [Trust - Indicators of Trust](./trust)
+
+The Indicator of Trust provides insight about data on what can be trusted and known as a good actor. Similar to a whitelist but on steroids, reusing features one would use with Indicators of Compromise, but to filter out what is known to be good.
 
 ### Vocabulary for Event Recording and Incident Sharing [VERIS](./veris)
 

--- a/trust/machinetag.json
+++ b/trust/machinetag.json
@@ -12,54 +12,6 @@
     },
     {
       "value": "change-likelihood"
-    },
-    {
-      "colour": "#2657ff",
-      "description": "This domain is known to be good",
-      "expanded": "A domain, the human name given to a host can be trusted",
-      "value": "domain"
-    },
-    {
-      "colour": "#e8c90e",
-      "description": "This IP is known to be good",
-      "expanded": "This IP address can be trusted",
-      "value": "ip"
-    },
-    {
-      "colour": "#0E40E8",
-      "description": "This SHA256 Hash can be trusted",
-      "expanded": "This SHA256 Hash can be trusted",
-      "value": "sha256"
-    },
-    {
-      "colour": "#0E40E8",
-      "description": "This SHA384 Hash can be trusted",
-      "expanded": "This SHA384 Hash can be trusted",
-      "value": "sha384"
-    },
-    {
-      "colour": "#0E40E8",
-      "description": "This SHA512 Hash can be trusted",
-      "expanded": "This SHA512 Hash can be trusted",
-      "value": "sha512"
-    },
-    {
-      "colour": "#00BD25",
-      "description": "This URI can be trusted",
-      "expanded": "This URI can be trusted",
-      "value": "uri"
-    },
-    {
-      "colour": "#00BD25",
-      "description": "This URL can be trusted",
-      "expanded": "This URL can be trusted",
-      "value": "url"
-    },
-    {
-      "colour": "#9D9D9D",
-      "description": "This email is trusted",
-      "expanded": "This email can be trusted",
-      "value": "email"
     }
   ],
   "values": [

--- a/trust/machinetag.json
+++ b/trust/machinetag.json
@@ -1,0 +1,133 @@
+{
+  "version": 1,
+  "description": "The Indicator of Trust provides insight about data on what can be trusted and known as a good actor. Similar to a whitelist but on steroids, reusing features one would use with Indicators of Compromise, but to filter out what is known to be good.",
+  "expanded": "Indicators of Trust",
+  "namespace": "trust",
+  "predicates": [
+    {
+      "value": "confidence"
+    },
+    {
+      "value": "periodicity"
+    },
+    {
+      "value": "change-likelihood"
+    },
+    {
+      "colour": "#2657ff",
+      "description": "This domain is known to be good",
+      "expanded": "A domain, the human name given to a host can be trusted",
+      "value": "domain"
+    },
+    {
+      "colour": "#e8c90e",
+      "description": "This IP is known to be good",
+      "expanded": "This IP address can be trusted",
+      "value": "ip"
+    },
+    {
+      "colour": "#0E40E8",
+      "description": "This SHA256 Hash can be trusted",
+      "expanded": "This SHA256 Hash can be trusted",
+      "value": "sha256"
+    },
+    {
+      "colour": "#0E40E8",
+      "description": "This SHA384 Hash can be trusted",
+      "expanded": "This SHA384 Hash can be trusted",
+      "value": "sha384"
+    },
+    {
+      "colour": "#0E40E8",
+      "description": "This SHA512 Hash can be trusted",
+      "expanded": "This SHA512 Hash can be trusted",
+      "value": "sha512"
+    },
+    {
+      "colour": "#00BD25",
+      "description": "This URI can be trusted",
+      "expanded": "This URI can be trusted",
+      "value": "uri"
+    },
+    {
+      "colour": "#00BD25",
+      "description": "This URL can be trusted",
+      "expanded": "This URL can be trusted",
+      "value": "url"
+    },
+    {
+      "colour": "#9D9D9D",
+      "description": "This email is trusted",
+      "expanded": "This email can be trusted",
+      "value": "email"
+    }
+  ],
+  "values": [
+    {
+      "predicate": "confidence",
+      "entry": [
+        {
+          "value": "high",
+          "expanded": "High confidence"
+        },
+        {
+          "value": "low",
+          "expanded": "Low confidence"
+        },
+        {
+          "value": "medium",
+          "expanded": "Medium confidence"
+        }
+      ]
+    },
+    {
+      "predicate": "periodicity",
+      "entry": [
+        {
+          "value": "hourly",
+          "expanded": "This attribute is likely to happen at an hourly interval"
+        },
+        {
+          "value": "daily",
+          "expanded": "This attribute is likely to happen at a daily interval"
+        },
+        {
+          "value": "weekly",
+          "expanded": "This attribute is likely to happen at a weekly interval"
+        },
+        {
+          "value": "monthly",
+          "expanded": "This attribute is likely to happen at a monthly interval"
+        },
+        {
+          "value": "yearly",
+          "expanded": "Thie attribute is likely to happen at a yearly interval"
+        }
+      ]
+    },
+    {
+      "predicate": "change-likelihood",
+      "entry": [
+        {
+          "value": "low",
+          "expanded": "Low change probability"
+        },
+        {
+          "value": "medium",
+          "expanded": "Medium change probability"
+        },
+        {
+          "value": "high",
+          "expanded": "High change probability"
+        },
+        {
+          "value": "unknown",
+          "expanded": "Unknown change probability"
+        }
+      ]
+    }
+  ],
+  "refs": [
+    "https://trust.fyi/"
+  ]
+}


### PR DESCRIPTION
This adds the trust taxonomy to MISP so we can start using attributes we have a confidence for being good in order to have a super whitelist which is the evil twin of how MISP operates now: based on things that are known to be bad. 