### PR TITLE
Proposal for whaling phishing

### DIFF
--- a/phishing/machinetag.json
+++ b/phishing/machinetag.json
@@ -95,6 +95,11 @@
           "expanded": "Bulk phishing",
           "description": "Adversary attempts to target a large group of potential targets without specific knowledge of the victims."
         }
+        {
+          "value": "whaling",
+          "expanded": "Whaling phishing",
+          "description": "Adversary attempts to target executives and high-level employees (like public spokespersons)."
+        }
       ]
     },
     {


### PR DESCRIPTION
Suggestion for another phishing attack related directors and executive employees, usually named also as Ceo Spoofing attack.