### PR TITLE
Creation of IOC taxonomy

### DIFF
--- a/ioc/machinetag.json
+++ b/ioc/machinetag.json
@@ -1,0 +1,26 @@
+{
+  "namespace": "ioc",
+  "description": "An IOC classification to facilitate automation of malicious and non malicious artifacts",
+  "version": 1,
+  "predicates": [
+    {
+      "value": "artifact-state",
+      "expanded": "Artifact State"
+    }
+  ],
+  "values": [
+    {
+      "predicate": "artifact state",
+      "entry": [
+        {
+          "value": "malicious",
+          "expanded": "Malicious"
+        },
+        {
+          "value": "not-malicious",
+          "expanded": "Not Malicious"
+        }
+      ]
+    }
+   ]
+}


### PR DESCRIPTION
The IOC taxonomy was created to address automation needs. 
As we share IoC's, some of them are not malicious in nature, but it's presence can point to something malicious happening.
For automation purposes, the use of data classification helps when you need to block something or not.