### PR TITLE
Correction de "Non classifiée" vers "Non protégé"

### DIFF
--- a/fr-classif/machinetag.json
+++ b/fr-classif/machinetag.json
@@ -23,8 +23,8 @@
           "colour": "#f87272"
         },
         {
-          "expanded": "NON CLASSIFIEES",
-          "value": "NON-CLASSIFIEES",
+          "expanded": "NON PROTEGE",
+          "value": "NON-PROTEGE",
           "colour": "#f89595"
         }
       ],
@@ -58,7 +58,7 @@
       "exclusive": false
     }
   ],
-  "version": 5,
+  "version": 6,
   "description": "French gov information classification system",
   "namespace": "fr-classif"
 }


### PR DESCRIPTION
L'IGI1300 décrit 2 niveaux de classification : Secret et Très Secret. Les informations ainsi protégées sont dites classifiées. L'IGI1300 (§1.3.2) précise également qu'il existe une mention de protection dite "Diffusion Restreinte" pour des informations non classifiées. Or, les informations non classifiées et non protégées par la mention Diffusion Restreinte sont dites "Non protégées".
Par cohérence avec les timbres "Secret" et "Très Secret", la mention "Non protégé" est proposée au masculin.