### PR TITLE
Making TLP and PAP taxonomy adhere to FIRST standard (color and uppercase value)

### DIFF
--- a/PAP/machinetag.json
+++ b/PAP/machinetag.json
@@ -2,27 +2,27 @@
   "namespace": "PAP",
   "expanded": "Permissible Actions Protocol",
   "description": "The Permissible Actions Protocol - or short: PAP - was designed to indicate how the received information can be used.",
-  "version": 2,
+  "version": 3,
   "exclusive": true,
   "predicates": [
     {
       "value": "RED",
       "expanded": "(PAP:RED) Non-detectable actions only. Recipients may not use PAP:RED information on the network. Only passive actions on logs, that are not detectable from the outside.",
-      "colour": "#ff0000"
+      "colour": "#ff2b2b"
     },
     {
       "value": "AMBER",
       "expanded": "(PAP:AMBER) Passive cross check. Recipients may use PAP:AMBER information for conducting online checks, like using services provided by third parties (e.g. VirusTotal), or set up a monitoring honeypot.",
-      "colour": "#ffa800"
+      "colour": "#ffc000"
     },
     {
       "value": "GREEN",
       "expanded": "(PAP:GREEN) Active actions allowed. Recipients may use PAP:GREEN information to ping the target, block incoming/outgoing traffic from/to the target or specifically configure honeypots to interact with the target.",
-      "colour": "#00ad1c"
+      "colour": "#33ff00"
     },
     {
-      "value": "WHITE",
-      "expanded": "(PAP:WHITE) No restrictions in using this information.",
+      "value": "CLEAR",
+      "expanded": "(PAP:CLEAR) No restrictions in using this information.",
       "colour": "#ffffff"
     }
   ]

--- a/PAP/machinetag.json
+++ b/PAP/machinetag.json
@@ -21,6 +21,11 @@
       "colour": "#33ff00"
     },
     {
+      "value": "WHITE",
+      "expanded": "(PAP:WHITE) No restrictions in using this information. This tag exists for backward compatibilty.",
+      "colour": "#ffffff"
+    },
+    {
       "value": "CLEAR",
       "expanded": "(PAP:CLEAR) No restrictions in using this information.",
       "colour": "#ffffff"

--- a/tlp/machinetag.json
+++ b/tlp/machinetag.json
@@ -4,50 +4,50 @@
       "colour": "#FF2B2B",
       "description": "For the eyes and ears of individual recipients only, no further disclosure. Sources may use TLP:RED when information cannot be effectively acted upon without significant risk for the privacy, reputation, or operations of the organizations involved. Recipients may therefore not share TLP:RED information with anyone else. In the context of a meeting, for example, TLP:RED information is limited to those present at the meeting.",
       "expanded": "(TLP:RED) For the eyes and ears of individual recipients only, no further disclosure.",
-      "value": "red"
+      "value": "RED"
     },
     {
       "colour": "#FFC000",
       "description": "Limited disclosure, recipients can only spread this on a need-to-know basis within their organization and its clients. Sources may use TLP:AMBER when information requires support to be effectively acted upon, yet carries risk to privacy, reputation, or operations if shared outside of the organizations involved. Recipients may share TLP:AMBER information with members of their own organization and its clients, but only on a need-to-know basis to protect their organization and its clients and prevent further harm. Note that TLP:AMBER+STRICT restricts sharing to the organization only.",
       "expanded": "(TLP:AMBER) Limited disclosure, recipients can only spread this on a need-to-know basis within their organization and its clients.",
-      "value": "amber"
+      "value": "AMBER"
     },
     {
       "colour": "#FFC000",
       "description": "Limited disclosure, recipients can only spread this on a need-to-know basis within their organization. Sources may use TLP:AMBER+STRICT when information requires support to be effectively acted upon, yet carries risk to privacy, reputation, or operations if shared outside of the organizations involved. Recipients may share TLP:AMBER+STRICT information with members of their own organization.",
-      "expanded": "Limited disclosure, recipients can only spread this on a need-to-know basis within their organization.",
-      "value": "amber+strict"
+      "expanded": "(TLP:AMBER+STRICT) Limited disclosure, recipients can only spread this on a need-to-know basis within their organization.",
+      "value": "AMBER+STRICT"
     },
     {
       "colour": "#33FF00",
       "description": "Limited disclosure, recipients can spread this within their community. Sources may use TLP:GREEN when information is useful to increase awareness within their wider community. Recipients may share TLP:GREEN information with peers and partner organizations within their community, but not via publicly accessible channels. TLP:GREEN information may not be shared outside of the community. Note: when “community” is not defined, assume the cybersecurity/defense community.",
       "expanded": "(TLP:GREEN) Limited disclosure, recipients can spread this within their community.",
-      "value": "green"
+      "value": "GREEN"
     },
     {
       "colour": "#ffffff",
       "description": "Disclosure is not limited.  Sources may use TLP:WHITE when information carries minimal or no foreseeable risk of misuse, in accordance with applicable rules and procedures for public release. Subject to standard copyright rules, TLP:WHITE information may be distributed without restriction. The version 2.0 of TLP doesn't mention anymore this tag which is most probably compatible with new TLP:CLEAR tag.",
       "expanded": "(TLP:WHITE) Information can be shared publicly in accordance with the law.",
-      "value": "white"
+      "value": "WHITE"
     },
     {
       "colour": "#ffffff",
       "description": "Recipients can spread this to the world, there is no limit on disclosure. Sources may use TLP:CLEAR when information carries minimal or no foreseeable risk of misuse, in accordance with applicable rules and procedures for public release. Subject to standard copyright rules, TLP:CLEAR information may be shared without restriction.",
       "expanded": "(TLP:CLEAR) Recipients can spread this to the world, there is no limit on disclosure.",
-      "value": "clear"
+      "value": "CLEAR"
     },
     {
       "colour": "#d208f4",
       "expanded": "(TLP:EX:CHR) Information extended with a specific tag called Chatham House Rule (CHR). When this specific CHR tag is mentioned, the attribution (the source of information) must not be disclosed. This additional rule is at the discretion of the initial sender who can decide to apply or not the CHR tag.",
-      "value": "ex:chr"
+      "value": "EX:CHR"
     }
   ],
   "refs": [
     "https://www.first.org/tlp"
   ],
-  "version": 7,
+  "version": 8,
   "description": "The Traffic Light Protocol (TLP) (v2.0) was created to facilitate greater sharing of potentially sensitive information and more effective collaboration. Information sharing happens from an information source, towards one or more recipients. TLP is a set of four standard labels (a fifth label is included in amber to limit the diffusion) used to indicate the sharing boundaries to be applied by the recipients. Only labels listed in this standard are considered valid by FIRST. This taxonomy includes additional labels for backward compatibility which are no more validated by FIRST SIG.",
   "expanded": "Traffic Light Protocol",
   "exclusive": true,
-  "namespace": "tlp"
+  "namespace": "TLP"
 }


### PR DESCRIPTION
Hello, in order to fix #86:

- Changing PAP:WHITE value to PAP:CLEAR for consistency between TLP and PAP taxonomy
- Changing PAP tags colors to match TLP tags colors
- Changing TLP tag values to uppercase to follow FIRST standard 


