### PR TITLE
Dark-Web Ransomware support 

### DIFF
--- a/dark-web/machinetag.json
+++ b/dark-web/machinetag.json
@@ -2,7 +2,7 @@
   "namespace": "dark-web",
   "expanded": "Dark Web",
   "description": "Criminal motivation and content detection the dark web: A categorisation model for law enforcement. ref: Janis Dalins, Campbell Wilson, Mark Carman. Taxonomy updated by MISP Project and extended by the JRC (Joint Research Centre) of the European Commission.",
-  "version": 5,
+  "version": 6,
   "predicates": [
     {
       "value": "topic",
@@ -360,6 +360,11 @@
           "description": "Videos and streaming"
         },
         {
+          "value": "ransomware-post",
+          "expanded": "ransomwarePost",
+          "description": "Ransomware post published by a ransomware group"
+        },
+        {
           "value": "unclear",
           "expanded": "unclear",
           "description": "Unable to completely establish structure of material."
@@ -473,6 +478,31 @@
           "value": "pgp-public-key-block",
           "expanded": "pgpPublicKeyBlock",
           "description": "PGP public key block identified in the dark-web site"
+        },
+        {
+          "value": "country",
+          "expanded": "country",
+          "description": "Associated country detected on the code of the dark-web site, following ISO 3166-1 alpha-2"
+        },
+        {
+          "value": "company-name",
+          "expanded": "companyName",
+          "description": "Company name identified in a dark-web site"
+        },
+        {
+          "value": "company-link",
+          "expanded": "companyLink",
+          "description": "Company link identified in a dark-web site"
+        },
+        {
+          "value": "victim-address",
+          "expanded": "victimAddress",
+          "description": "Business address identified in a dark-web site"
+        },
+        {
+          "value": "victim-TLD",
+          "expanded": "victimTLD",
+          "description": "Business Top Level Domain (TLD) of a company identified in a dark-web site"
         }
       ]
     }


### PR DESCRIPTION
The Joint Research Centre (JRC) has worked on the extension of the existent dark-web taxonomy now supporting the presence of ransomware groups on the darknet. 