### PR TITLE
Update machinetag.json

### DIFF
--- a/malware_classification/machinetag.json
+++ b/malware_classification/machinetag.json
@@ -61,6 +61,10 @@
           "expanded": "Spyware"
         },
         {
+          "value": "Zombieware",
+          "expanded": "Zombieware"
+        },
+        {
           "value": "Botnet",
           "expanded": "Botnet"
         }


### PR DESCRIPTION
Added Zombieware category, malware that has been abandoned by its operators, and despite being abandoned, new replications of the malware continue to appear in the wild.