### PR TITLE
Adapt PAP:AMBER description

### DIFF
--- a/PAP/machinetag.json
+++ b/PAP/machinetag.json
@@ -13,7 +13,7 @@
     },
     {
       "value": "AMBER",
-      "expanded": "(PAP:AMBER) Passive cross check. Recipients may use PAP:AMBER information for conducting online checks, like using services provided by third parties (e.g. VirusTotal), or set up a monitoring honeypot.",
+      "expanded": "(PAP:AMBER) Passive cross check. Recipients may use PAP:AMBER information for conducting online checks, like using services provided by third parties (e.g. ripe whois), or set up a monitoring honeypot.",
       "colour": "#ffc000",
       "uuid": "09f19595-73dc-5cc2-8e56-48a8403e4053"
     },


### PR DESCRIPTION
I propose to remove Virustotal as a passive lookup tool, since Virustotal actively scans an IP address if it is not already present in its database. Hence this action breaks the PAP:AMBER restriction that you are not allowed initiate contact with the as PAP:AMBER classified system.