### PR TITLE
Add `cti-evaluation` taxonomy for CTI quality and conversion assessment

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -4,31 +4,6 @@
   "path": "machinetag.json",
   "taxonomies": [
     {
-      "description": "CERT-XLM Security Incident Classification.",
-      "name": "CERT-XLM",
-      "version": 2
-    },
-    {
-      "description": "DFRLab Dichotomies of Disinformation.",
-      "name": "DFRLab-dichotomies-of-disinformation",
-      "version": 1
-    },
-    {
-      "description": "The Detection Maturity Level (DML) model is a capability maturity model for referencing ones maturity in detecting cyber attacks.  It's designed for organizations who perform intel-driven detection and response and who put an emphasis on having a mature detection program.",
-      "name": "DML",
-      "version": 1
-    },
-    {
-      "description": "Gray Zone of Active defense includes all elements which lay between reactive defense elements and offensive operations. It does fill the gray spot between them. Taxo may be used for active defense planning or modeling.",
-      "name": "GrayZone",
-      "version": 3
-    },
-    {
-      "description": "The Permissible Actions Protocol - or short: PAP - was designed to indicate how the received information can be used.",
-      "name": "PAP",
-      "version": 3
-    },
-    {
       "description": "The access method used to remotely access a system.",
       "name": "access-method",
       "version": 1
@@ -129,6 +104,11 @@
       "version": 2
     },
     {
+      "description": "CERT-XLM Security Incident Classification.",
+      "name": "CERT-XLM",
+      "version": 2
+    },
+    {
       "description": "CIRCL Taxonomy - Schemes of Classification in Incident Response and Detection.",
       "name": "circl",
       "version": 6
@@ -139,7 +119,7 @@
       "version": 1
     },
     {
-      "description": "La presente taxonomia es la primera versión disponible para el Centro Nacional de Seguridad Digital del Perú.",
+      "description": "La presente taxonomia es la primera versi\u00f3n disponible para el Centro Nacional de Seguridad Digital del Per\u00fa.",
       "name": "cnsd",
       "version": 20220513
     },
@@ -179,12 +159,12 @@
       "version": 2
     },
     {
-      "description": "Taxonomía CSIRT Américas.",
+      "description": "Taxonom\u00eda CSIRT Am\u00e9ricas.",
       "name": "csirt-americas",
       "version": 1
     },
     {
-      "description": "It is critical that the CSIRT provide consistent and timely response to the customer, and that sensitive information is handled appropriately.  This document provides the guidelines needed for CSIRT Incident Managers (IM) to classify the case category, criticality level, and sensitivity level for each CSIRT case.  This information will be entered into the Incident Tracking System (ITS) when a case is created.  Consistent case classification is required for the CSIRT to provide accurate reporting to management on a regular basis.  In addition, the classifications will provide CSIRT IM’s with proper case handling procedures and will form the basis of SLA’s between the CSIRT and other Company departments.",
+      "description": "It is critical that the CSIRT provide consistent and timely response to the customer, and that sensitive information is handled appropriately.  This document provides the guidelines needed for CSIRT Incident Managers (IM) to classify the case category, criticality level, and sensitivity level for each CSIRT case.  This information will be entered into the Incident Tracking System (ITS) when a case is created.  Consistent case classification is required for the CSIRT to provide accurate reporting to management on a regular basis.  In addition, the classifications will provide CSIRT IM\u2019s with proper case handling procedures and will form the basis of SLA\u2019s between the CSIRT and other Company departments.",
       "name": "csirt_case_classification",
       "version": 1
     },
@@ -196,6 +176,11 @@
     {
       "description": "Cyber Threat Intelligence cycle to control workflow state of your process.",
       "name": "cti",
+      "version": 1
+    },
+    {
+      "name": "cti-evaluation",
+      "description": "Evaluation taxonomy for cyber threat intelligence (CTI) quality and conversion quality in workflows such as MISP/STIX exchange and CTI Transmute, covering relevance, accuracy, timeliness, clarity, specificity, format validity, conversion fidelity, and usefulness.",
       "version": 1
     },
     {
@@ -259,6 +244,11 @@
       "version": 1
     },
     {
+      "description": "DFRLab Dichotomies of Disinformation.",
+      "name": "DFRLab-dichotomies-of-disinformation",
+      "version": 1
+    },
+    {
       "description": "A taxonomy to describe domain-generation algorithms often called DGA. Ref: A Comprehensive Measurement Study of Domain Generating Malware Daniel Plohmann and others.",
       "name": "dga",
       "version": 2
@@ -276,6 +266,11 @@
     {
       "description": "The diamond model for influence operations analysis is a framework that leads analysts and researchers toward a comprehensive understanding of a malign influence campaign by addressing the socio-political, technical, and psychological aspects of the campaign. The diamond model for influence operations analysis consists of 5 components: 4 corners and a core element. The 4 corners are divided into 2 axes: influencer and audience on the socio-political axis, capabilities and infrastructure on the technical axis. Narrative makes up the core of the diamond.",
       "name": "diamond-model-for-influence-operations",
+      "version": 1
+    },
+    {
+      "description": "The Detection Maturity Level (DML) model is a capability maturity model for referencing ones maturity in detecting cyber attacks.  It's designed for organizations who perform intel-driven detection and response and who put an emphasis on having a mature detection program.",
+      "name": "DML",
       "version": 1
     },
     {
@@ -374,7 +369,7 @@
       "version": 2
     },
     {
-      "description": "The purpose of this taxonomy is to jointly tabulate both the of these failure modes in a single place. Intentional failures wherein the failure is caused by an active adversary attempting to subvert the system to attain her goals – either to misclassify the result, infer private training data, or to steal the underlying algorithm. Unintentional failures wherein the failure is because an ML system produces a formally correct but completely unsafe outcome.",
+      "description": "The purpose of this taxonomy is to jointly tabulate both the of these failure modes in a single place. Intentional failures wherein the failure is caused by an active adversary attempting to subvert the system to attain her goals \u2013 either to misclassify the result, infer private training data, or to steal the underlying algorithm. Unintentional failures wherein the failure is because an ML system produces a formally correct but completely unsafe outcome.",
       "name": "failure-mode-in-machine-learning",
       "version": 1
     },
@@ -414,7 +409,7 @@
       "version": 0
     },
     {
-      "description": "Information needed to track or monitor moments, periods or events that occur over time. This type of information is focused on occurrences that must be tracked for business reasons or represent a specific point in the evolution of ‘The Business’.",
+      "description": "Information needed to track or monitor moments, periods or events that occur over time. This type of information is focused on occurrences that must be tracked for business reasons or represent a specific point in the evolution of \u2018The Business\u2019.",
       "name": "gea-nz-activities",
       "version": 1
     },
@@ -427,6 +422,11 @@
       "description": "Information relating to authority or governance.",
       "name": "gea-nz-motivators",
       "version": 1
+    },
+    {
+      "description": "Gray Zone of Active defense includes all elements which lay between reactive defense elements and offensive operations. It does fill the gray spot between them. Taxo may be used for active defense planning or modeling.",
+      "name": "GrayZone",
+      "version": 3
     },
     {
       "description": "Taxonomy used by GSMA for their information sharing program with telco describing the attack categories",
@@ -444,7 +444,7 @@
       "version": 3
     },
     {
-      "description": "Updated (CIRCL, Seamus Dowling and EURECOM) from Christian Seifert, Ian Welch, Peter Komisarczuk, ‘Taxonomy of Honeypots’, Technical Report CS-TR-06/12, VICTORIA UNIVERSITY OF WELLINGTON, School of Mathematical and Computing Sciences, June 2006, http://www.mcs.vuw.ac.nz/comp/Publications/archive/CS-TR-06/CS-TR-06-12.pdf",
+      "description": "Updated (CIRCL, Seamus Dowling and EURECOM) from Christian Seifert, Ian Welch, Peter Komisarczuk, \u2018Taxonomy of Honeypots\u2019, Technical Report CS-TR-06/12, VICTORIA UNIVERSITY OF WELLINGTON, School of Mathematical and Computing Sciences, June 2006, http://www.mcs.vuw.ac.nz/comp/Publications/archive/CS-TR-06/CS-TR-06-12.pdf",
       "name": "honeypot-basic",
       "version": 4
     },
@@ -644,6 +644,11 @@
       "version": 4
     },
     {
+      "description": "The Permissible Actions Protocol - or short: PAP - was designed to indicate how the received information can be used.",
+      "name": "PAP",
+      "version": 3
+    },
+    {
       "description": "Tags from RiskIQ's PassiveTotal service",
       "name": "passivetotal",
       "version": 2
@@ -654,7 +659,7 @@
       "version": 3
     },
     {
-      "description": "Le Protocole des feux de circulation (PFC) est basé sur le standard « Traffic Light Protocol (TLP) » conçu par le FIRST. Il a pour objectif d’informer sur les limites autorisées pour la diffusion des informations. Il est classé selon des codes de couleurs.",
+      "description": "Le Protocole des feux de circulation (PFC) est bas\u00e9 sur le standard \u00ab Traffic Light Protocol (TLP) \u00bb con\u00e7u par le FIRST. Il a pour objectif d\u2019informer sur les limites autoris\u00e9es pour la diffusion des informations. Il est class\u00e9 selon des codes de couleurs.",
       "name": "pfc",
       "version": 1
     },
@@ -769,7 +774,7 @@
       "version": 1
     },
     {
-      "description": "The Targeted Threat Index is a metric for assigning an overall threat ranking score to email messages that deliver malware to a victim’s computer. The TTI metric was first introduced at SecTor 2013 by Seth Hardy as part of the talk “RATastrophe: Monitoring a Malware Menagerie” along with Katie Kleemola and Greg Wiseman.",
+      "description": "The Targeted Threat Index is a metric for assigning an overall threat ranking score to email messages that deliver malware to a victim\u2019s computer. The TTI metric was first introduced at SecTor 2013 by Seth Hardy as part of the talk \u201cRATastrophe: Monitoring a Malware Menagerie\u201d along with Katie Kleemola and Greg Wiseman.",
       "name": "targeted-threat-index",
       "version": 3
     },
@@ -784,7 +789,7 @@
       "version": 3
     },
     {
-      "description": "An overview of some of the known attacks related to DNS as described by Torabi, S., Boukhtouta, A., Assi, C., & Debbabi, M. (2018) in Detecting Internet Abuse by Analyzing Passive DNS Traffic: A Survey of Implemented Systems. IEEE Communications Surveys & Tutorials, 1–1. doi:10.1109/comst.2018.2849614",
+      "description": "An overview of some of the known attacks related to DNS as described by Torabi, S., Boukhtouta, A., Assi, C., & Debbabi, M. (2018) in Detecting Internet Abuse by Analyzing Passive DNS Traffic: A Survey of Implemented Systems. IEEE Communications Surveys & Tutorials, 1\u20131. doi:10.1109/comst.2018.2849614",
       "name": "threats-to-dns",
       "version": 1
     },
@@ -839,7 +844,7 @@
       "version": 1
     },
     {
-      "description": "Ce vocabulaire attribue des valeurs en pourcentage à certains énoncés de probabilité",
+      "description": "Ce vocabulaire attribue des valeurs en pourcentage \u00e0 certains \u00e9nonc\u00e9s de probabilit\u00e9",
       "name": "vocabulaire-des-probabilites-estimatives",
       "version": 3
     },

--- a/cti-evaluation/machinetag.json
+++ b/cti-evaluation/machinetag.json
@@ -1,0 +1,515 @@
+{
+  "namespace": "cti-evaluation",
+  "expanded": "CTI evaluation",
+  "description": "Evaluation taxonomy for cyber threat intelligence (CTI) quality and conversion quality in workflows such as MISP/STIX exchange and CTI Transmute, covering relevance, accuracy, timeliness, clarity, specificity, format validity, conversion fidelity, and usefulness.",
+  "version": 1,
+  "predicates": [
+    {
+      "value": "overall-score",
+      "expanded": "Overall CTI evaluation score",
+      "description": "Overall weighted assessment of the CTI artifact quality.",
+      "exclusive": true,
+      "uuid": "f50364e4-7208-4aa5-902d-972558e7b83b"
+    },
+    {
+      "value": "relevance",
+      "expanded": "Relevance",
+      "description": "Whether the CTI pertains directly to user mission and decision-making needs.",
+      "exclusive": true,
+      "uuid": "28ad5cfd-51ba-49a7-bc9f-3f1224d21d53"
+    },
+    {
+      "value": "accuracy",
+      "expanded": "Accuracy",
+      "description": "Whether assertions are based on reliable, verified, and corroborated data.",
+      "exclusive": true,
+      "uuid": "23c49abd-8daa-4ec3-bff9-70d7ca0f5679"
+    },
+    {
+      "value": "timeliness",
+      "expanded": "Timeliness",
+      "description": "Whether CTI is delivered with enough lead time for effective action.",
+      "exclusive": true,
+      "uuid": "17a8fb50-1b38-4032-b387-36a47c215015"
+    },
+    {
+      "value": "clarity",
+      "expanded": "Clarity",
+      "description": "Whether CTI is understandable, unambiguous, and actionable for intended audiences.",
+      "exclusive": true,
+      "uuid": "6297c509-92aa-4ece-b027-8574658e8cc0"
+    },
+    {
+      "value": "specificity",
+      "expanded": "Specificity",
+      "description": "Whether CTI contains concrete details (what, where, when, who, how) needed to act.",
+      "exclusive": true,
+      "uuid": "2a0ad1ec-d7d7-4a0d-a5e6-cdc6fb9f9ee3"
+    },
+    {
+      "value": "usefulness",
+      "expanded": "Usefulness",
+      "description": "Practical utility of CTI for operations, detection, response, or strategic decisions.",
+      "exclusive": true,
+      "uuid": "4a962a11-ea5b-4a90-816e-fe7ae44fdbf5"
+    },
+    {
+      "value": "format-validity",
+      "expanded": "Format validity",
+      "description": "Conformance of CTI artifacts to expected schema/syntax (e.g., STIX/MISP structures).",
+      "exclusive": true,
+      "uuid": "22c47f47-0b1a-4b2c-a1f9-90d3b9a1930c"
+    },
+    {
+      "value": "conversion-fidelity",
+      "expanded": "Conversion fidelity",
+      "description": "How faithfully intelligence survives format conversion (e.g., MISP to STIX and back).",
+      "exclusive": true,
+      "uuid": "01bd3d97-97af-4bd0-a50a-e3c245daff29"
+    },
+    {
+      "value": "source-reliability",
+      "expanded": "Source reliability",
+      "description": "Reliability of primary and secondary sources underpinning the CTI.",
+      "exclusive": true,
+      "uuid": "ad4b61fa-c876-47b6-881f-9e9159d1455f"
+    },
+    {
+      "value": "evidence-strength",
+      "expanded": "Evidence strength",
+      "description": "Strength and sufficiency of supporting evidence for the claims.",
+      "exclusive": true,
+      "uuid": "433fcff9-7ee9-47fc-a6a0-84c5f706d695"
+    },
+    {
+      "value": "confidence",
+      "expanded": "Confidence",
+      "description": "Analyst or reviewer confidence in the CTI judgments.",
+      "exclusive": true,
+      "uuid": "f10f3d35-a0c0-40de-8540-72c301c27c1c"
+    }
+  ],
+  "values": [
+    {
+      "predicate": "overall-score",
+      "entry": [
+        {
+          "value": "very-low",
+          "expanded": "Very low",
+          "numerical_value": 0,
+          "uuid": "ccb04e14-0a16-43f4-a058-b3b75d70371d"
+        },
+        {
+          "value": "low",
+          "expanded": "Low",
+          "numerical_value": 25,
+          "uuid": "c2ca918b-9a24-4537-9993-317b9711cdef"
+        },
+        {
+          "value": "moderate",
+          "expanded": "Moderate",
+          "numerical_value": 50,
+          "uuid": "33b5ef27-c90b-4c66-b488-ce30c259daac"
+        },
+        {
+          "value": "high",
+          "expanded": "High",
+          "numerical_value": 75,
+          "uuid": "69efb1c9-a4e3-4911-878d-0bffba0420d4"
+        },
+        {
+          "value": "very-high",
+          "expanded": "Very high",
+          "numerical_value": 100,
+          "uuid": "ef497ab8-4304-4e77-a0a8-1e0592916956"
+        }
+      ]
+    },
+    {
+      "predicate": "relevance",
+      "entry": [
+        {
+          "value": "very-low",
+          "expanded": "Very low",
+          "numerical_value": 0,
+          "uuid": "2b071e2f-f185-4045-a576-89afd732bb6f"
+        },
+        {
+          "value": "low",
+          "expanded": "Low",
+          "numerical_value": 25,
+          "uuid": "12868087-9ae9-4da7-8df2-b7c6f86c8420"
+        },
+        {
+          "value": "moderate",
+          "expanded": "Moderate",
+          "numerical_value": 50,
+          "uuid": "602b1a41-6d39-4d93-98b9-962abcc25e14"
+        },
+        {
+          "value": "high",
+          "expanded": "High",
+          "numerical_value": 75,
+          "uuid": "9c194177-cd5d-48f5-a59a-fb2926571b46"
+        },
+        {
+          "value": "very-high",
+          "expanded": "Very high",
+          "numerical_value": 100,
+          "uuid": "54907a4f-dadb-4a14-bc6d-06898946d80f"
+        }
+      ]
+    },
+    {
+      "predicate": "accuracy",
+      "entry": [
+        {
+          "value": "very-low",
+          "expanded": "Very low",
+          "numerical_value": 0,
+          "uuid": "8345b53c-ed4c-4cce-82a4-603fae49da4b"
+        },
+        {
+          "value": "low",
+          "expanded": "Low",
+          "numerical_value": 25,
+          "uuid": "4d0f60ee-19fb-4c86-92f1-65026a4a6d3a"
+        },
+        {
+          "value": "moderate",
+          "expanded": "Moderate",
+          "numerical_value": 50,
+          "uuid": "ec2c0ad4-e4c1-4d3c-b654-35c989eea54f"
+        },
+        {
+          "value": "high",
+          "expanded": "High",
+          "numerical_value": 75,
+          "uuid": "3eb209ad-a750-4296-a626-ccdce0873ad3"
+        },
+        {
+          "value": "very-high",
+          "expanded": "Very high",
+          "numerical_value": 100,
+          "uuid": "6f8ec488-cceb-4e18-b5eb-6c9d00949d8b"
+        }
+      ]
+    },
+    {
+      "predicate": "timeliness",
+      "entry": [
+        {
+          "value": "very-low",
+          "expanded": "Very low",
+          "numerical_value": 0,
+          "uuid": "2c13e47c-9ac0-4f24-a2a4-505296da2a6c"
+        },
+        {
+          "value": "low",
+          "expanded": "Low",
+          "numerical_value": 25,
+          "uuid": "b3c3f2b2-c61a-4ccb-8a0a-58124d9a6f85"
+        },
+        {
+          "value": "moderate",
+          "expanded": "Moderate",
+          "numerical_value": 50,
+          "uuid": "d335bc11-fffc-478f-8076-3b187b9c4a91"
+        },
+        {
+          "value": "high",
+          "expanded": "High",
+          "numerical_value": 75,
+          "uuid": "92beb810-873f-42cf-a9a3-a216e85ca49a"
+        },
+        {
+          "value": "very-high",
+          "expanded": "Very high",
+          "numerical_value": 100,
+          "uuid": "f4ab1481-4fed-4ea5-ba0d-4623a0e7a5fa"
+        }
+      ]
+    },
+    {
+      "predicate": "clarity",
+      "entry": [
+        {
+          "value": "very-low",
+          "expanded": "Very low",
+          "numerical_value": 0,
+          "uuid": "0ec05c80-dfba-486e-a58e-c5447119f1b7"
+        },
+        {
+          "value": "low",
+          "expanded": "Low",
+          "numerical_value": 25,
+          "uuid": "2279ea56-761a-43f6-b647-199b834aa776"
+        },
+        {
+          "value": "moderate",
+          "expanded": "Moderate",
+          "numerical_value": 50,
+          "uuid": "718535c4-efa7-4546-b93b-e9b533a9bfd9"
+        },
+        {
+          "value": "high",
+          "expanded": "High",
+          "numerical_value": 75,
+          "uuid": "e1ca5e3f-bad3-45c7-8556-24ede6652656"
+        },
+        {
+          "value": "very-high",
+          "expanded": "Very high",
+          "numerical_value": 100,
+          "uuid": "840866db-8e56-4b41-bebf-db18b12c2b28"
+        }
+      ]
+    },
+    {
+      "predicate": "specificity",
+      "entry": [
+        {
+          "value": "very-low",
+          "expanded": "Very low",
+          "numerical_value": 0,
+          "uuid": "e1efcaa5-4562-48fa-8ddb-89e7785b12ea"
+        },
+        {
+          "value": "low",
+          "expanded": "Low",
+          "numerical_value": 25,
+          "uuid": "76c8f204-2218-4f64-83ea-2fe4b8de38ef"
+        },
+        {
+          "value": "moderate",
+          "expanded": "Moderate",
+          "numerical_value": 50,
+          "uuid": "a98d664e-996d-4973-a4b6-45ef9f8df7ac"
+        },
+        {
+          "value": "high",
+          "expanded": "High",
+          "numerical_value": 75,
+          "uuid": "25a3aa66-779e-426d-b016-01653fe56f89"
+        },
+        {
+          "value": "very-high",
+          "expanded": "Very high",
+          "numerical_value": 100,
+          "uuid": "0a062f3d-3d7c-43f9-8c2f-e7ed3d466d6c"
+        }
+      ]
+    },
+    {
+      "predicate": "usefulness",
+      "entry": [
+        {
+          "value": "very-low",
+          "expanded": "Very low",
+          "numerical_value": 0,
+          "uuid": "b5c3b394-dd65-4046-acbd-905756eb5c58"
+        },
+        {
+          "value": "low",
+          "expanded": "Low",
+          "numerical_value": 25,
+          "uuid": "99fc1436-04ae-43b9-a493-e7b1d9b385b6"
+        },
+        {
+          "value": "moderate",
+          "expanded": "Moderate",
+          "numerical_value": 50,
+          "uuid": "7d11ecf5-efe0-461b-b0fe-742da25b2358"
+        },
+        {
+          "value": "high",
+          "expanded": "High",
+          "numerical_value": 75,
+          "uuid": "2de05f07-069f-4869-b42f-1708893ee568"
+        },
+        {
+          "value": "very-high",
+          "expanded": "Very high",
+          "numerical_value": 100,
+          "uuid": "49377759-ba5c-4975-a0d1-dccc5b5bdd3c"
+        }
+      ]
+    },
+    {
+      "predicate": "format-validity",
+      "entry": [
+        {
+          "value": "very-low",
+          "expanded": "Very low",
+          "numerical_value": 0,
+          "uuid": "b12231a8-330f-406b-a62c-44c96cf6be57"
+        },
+        {
+          "value": "low",
+          "expanded": "Low",
+          "numerical_value": 25,
+          "uuid": "0923d55e-dbbe-46a5-bb40-366ec9fad559"
+        },
+        {
+          "value": "moderate",
+          "expanded": "Moderate",
+          "numerical_value": 50,
+          "uuid": "3122228c-12fe-4a55-8393-17d19eb2bced"
+        },
+        {
+          "value": "high",
+          "expanded": "High",
+          "numerical_value": 75,
+          "uuid": "fb9aefc2-860c-4a7f-87c4-61daba5d61dd"
+        },
+        {
+          "value": "very-high",
+          "expanded": "Very high",
+          "numerical_value": 100,
+          "uuid": "8b9f3ce8-30f6-4b5c-8992-899aedb1a6f5"
+        }
+      ]
+    },
+    {
+      "predicate": "conversion-fidelity",
+      "entry": [
+        {
+          "value": "very-low",
+          "expanded": "Very low",
+          "numerical_value": 0,
+          "uuid": "7ca279d8-809c-4029-bdd5-c2fab201f862"
+        },
+        {
+          "value": "low",
+          "expanded": "Low",
+          "numerical_value": 25,
+          "uuid": "d0d97b5c-fc44-44df-9929-27b3bf6ca7f5"
+        },
+        {
+          "value": "moderate",
+          "expanded": "Moderate",
+          "numerical_value": 50,
+          "uuid": "724f78a7-7bb5-45bc-b0f4-f01abb9283d0"
+        },
+        {
+          "value": "high",
+          "expanded": "High",
+          "numerical_value": 75,
+          "uuid": "a3d88da1-9df5-4f41-b2ca-6a7fdd84c2dc"
+        },
+        {
+          "value": "very-high",
+          "expanded": "Very high",
+          "numerical_value": 100,
+          "uuid": "3098e418-10b5-44ae-ac60-f6bd24829ade"
+        }
+      ]
+    },
+    {
+      "predicate": "source-reliability",
+      "entry": [
+        {
+          "value": "very-low",
+          "expanded": "Very low",
+          "numerical_value": 0,
+          "uuid": "35a05b9d-3d79-499d-8c4a-8f5a060d9e5d"
+        },
+        {
+          "value": "low",
+          "expanded": "Low",
+          "numerical_value": 25,
+          "uuid": "0db4a77b-0602-4ab8-a813-ac51a2c38a8e"
+        },
+        {
+          "value": "moderate",
+          "expanded": "Moderate",
+          "numerical_value": 50,
+          "uuid": "3f1994dd-0a98-44a7-8cd1-917be5921c4c"
+        },
+        {
+          "value": "high",
+          "expanded": "High",
+          "numerical_value": 75,
+          "uuid": "ed2fba05-d8ab-44d1-8fcf-81a3f2326130"
+        },
+        {
+          "value": "very-high",
+          "expanded": "Very high",
+          "numerical_value": 100,
+          "uuid": "1d57ec60-2821-4f21-a6c3-7fe17bb73612"
+        }
+      ]
+    },
+    {
+      "predicate": "evidence-strength",
+      "entry": [
+        {
+          "value": "very-low",
+          "expanded": "Very low",
+          "numerical_value": 0,
+          "uuid": "4b709dec-7414-47bc-97b2-730295afc971"
+        },
+        {
+          "value": "low",
+          "expanded": "Low",
+          "numerical_value": 25,
+          "uuid": "77f09051-6fb7-4425-819d-380d213bb770"
+        },
+        {
+          "value": "moderate",
+          "expanded": "Moderate",
+          "numerical_value": 50,
+          "uuid": "e07e90b9-d824-4b8d-ac20-fd4c52b8af54"
+        },
+        {
+          "value": "high",
+          "expanded": "High",
+          "numerical_value": 75,
+          "uuid": "7d860416-8123-4471-a1de-5f78fa149c46"
+        },
+        {
+          "value": "very-high",
+          "expanded": "Very high",
+          "numerical_value": 100,
+          "uuid": "4ab016de-464e-4a25-bb47-cbbbd2cf24a8"
+        }
+      ]
+    },
+    {
+      "predicate": "confidence",
+      "entry": [
+        {
+          "value": "very-low",
+          "expanded": "Very low",
+          "numerical_value": 0,
+          "uuid": "b569eedc-9dc6-4dc1-bf28-a4c9ca878b52"
+        },
+        {
+          "value": "low",
+          "expanded": "Low",
+          "numerical_value": 25,
+          "uuid": "327e5669-0edf-46a4-bc15-fccbff70a757"
+        },
+        {
+          "value": "moderate",
+          "expanded": "Moderate",
+          "numerical_value": 50,
+          "uuid": "668ddd74-8c94-4da8-b939-cd4c1c7f903d"
+        },
+        {
+          "value": "high",
+          "expanded": "High",
+          "numerical_value": 75,
+          "uuid": "2e4d78b8-bcfc-49da-8e51-9c6d11a8e4fb"
+        },
+        {
+          "value": "very-high",
+          "expanded": "Very high",
+          "numerical_value": 100,
+          "uuid": "91f8d6e0-9d65-4752-9cb7-62a259e2af5b"
+        }
+      ]
+    }
+  ],
+  "uuid": "b376f2ae-5e40-47fd-b680-bb0464107949"
+}

--- a/cti-evaluation/machinetag.json
+++ b/cti-evaluation/machinetag.json
@@ -97,31 +97,36 @@
           "value": "very-low",
           "expanded": "Very low",
           "numerical_value": 0,
-          "uuid": "ccb04e14-0a16-43f4-a058-b3b75d70371d"
+          "uuid": "ccb04e14-0a16-43f4-a058-b3b75d70371d",
+          "description": "Very limited quality for this dimension; significant deficiencies were observed. Overall weighted assessment of the CTI artifact quality."
         },
         {
           "value": "low",
           "expanded": "Low",
           "numerical_value": 25,
-          "uuid": "c2ca918b-9a24-4537-9993-317b9711cdef"
+          "uuid": "c2ca918b-9a24-4537-9993-317b9711cdef",
+          "description": "Below expected quality for this dimension; notable weaknesses remain. Overall weighted assessment of the CTI artifact quality."
         },
         {
           "value": "moderate",
           "expanded": "Moderate",
           "numerical_value": 50,
-          "uuid": "33b5ef27-c90b-4c66-b488-ce30c259daac"
+          "uuid": "33b5ef27-c90b-4c66-b488-ce30c259daac",
+          "description": "Partially meets expectations for this dimension; acceptable but with clear gaps. Overall weighted assessment of the CTI artifact quality."
         },
         {
           "value": "high",
           "expanded": "High",
           "numerical_value": 75,
-          "uuid": "69efb1c9-a4e3-4911-878d-0bffba0420d4"
+          "uuid": "69efb1c9-a4e3-4911-878d-0bffba0420d4",
+          "description": "Strong quality for this dimension; minor limitations may remain. Overall weighted assessment of the CTI artifact quality."
         },
         {
           "value": "very-high",
           "expanded": "Very high",
           "numerical_value": 100,
-          "uuid": "ef497ab8-4304-4e77-a0a8-1e0592916956"
+          "uuid": "ef497ab8-4304-4e77-a0a8-1e0592916956",
+          "description": "Excellent quality for this dimension; fully or near-fully meets expectations. Overall weighted assessment of the CTI artifact quality."
         }
       ]
     },
@@ -132,31 +137,36 @@
           "value": "very-low",
           "expanded": "Very low",
           "numerical_value": 0,
-          "uuid": "2b071e2f-f185-4045-a576-89afd732bb6f"
+          "uuid": "2b071e2f-f185-4045-a576-89afd732bb6f",
+          "description": "Very limited quality for this dimension; significant deficiencies were observed. Whether the CTI pertains directly to user mission and decision-making needs."
         },
         {
           "value": "low",
           "expanded": "Low",
           "numerical_value": 25,
-          "uuid": "12868087-9ae9-4da7-8df2-b7c6f86c8420"
+          "uuid": "12868087-9ae9-4da7-8df2-b7c6f86c8420",
+          "description": "Below expected quality for this dimension; notable weaknesses remain. Whether the CTI pertains directly to user mission and decision-making needs."
         },
         {
           "value": "moderate",
           "expanded": "Moderate",
           "numerical_value": 50,
-          "uuid": "602b1a41-6d39-4d93-98b9-962abcc25e14"
+          "uuid": "602b1a41-6d39-4d93-98b9-962abcc25e14",
+          "description": "Partially meets expectations for this dimension; acceptable but with clear gaps. Whether the CTI pertains directly to user mission and decision-making needs."
         },
         {
           "value": "high",
           "expanded": "High",
           "numerical_value": 75,
-          "uuid": "9c194177-cd5d-48f5-a59a-fb2926571b46"
+          "uuid": "9c194177-cd5d-48f5-a59a-fb2926571b46",
+          "description": "Strong quality for this dimension; minor limitations may remain. Whether the CTI pertains directly to user mission and decision-making needs."
         },
         {
           "value": "very-high",
           "expanded": "Very high",
           "numerical_value": 100,
-          "uuid": "54907a4f-dadb-4a14-bc6d-06898946d80f"
+          "uuid": "54907a4f-dadb-4a14-bc6d-06898946d80f",
+          "description": "Excellent quality for this dimension; fully or near-fully meets expectations. Whether the CTI pertains directly to user mission and decision-making needs."
         }
       ]
     },
@@ -167,31 +177,36 @@
           "value": "very-low",
           "expanded": "Very low",
           "numerical_value": 0,
-          "uuid": "8345b53c-ed4c-4cce-82a4-603fae49da4b"
+          "uuid": "8345b53c-ed4c-4cce-82a4-603fae49da4b",
+          "description": "Very limited quality for this dimension; significant deficiencies were observed. Whether assertions are based on reliable, verified, and corroborated data."
         },
         {
           "value": "low",
           "expanded": "Low",
           "numerical_value": 25,
-          "uuid": "4d0f60ee-19fb-4c86-92f1-65026a4a6d3a"
+          "uuid": "4d0f60ee-19fb-4c86-92f1-65026a4a6d3a",
+          "description": "Below expected quality for this dimension; notable weaknesses remain. Whether assertions are based on reliable, verified, and corroborated data."
         },
         {
           "value": "moderate",
           "expanded": "Moderate",
           "numerical_value": 50,
-          "uuid": "ec2c0ad4-e4c1-4d3c-b654-35c989eea54f"
+          "uuid": "ec2c0ad4-e4c1-4d3c-b654-35c989eea54f",
+          "description": "Partially meets expectations for this dimension; acceptable but with clear gaps. Whether assertions are based on reliable, verified, and corroborated data."
         },
         {
           "value": "high",
           "expanded": "High",
           "numerical_value": 75,
-          "uuid": "3eb209ad-a750-4296-a626-ccdce0873ad3"
+          "uuid": "3eb209ad-a750-4296-a626-ccdce0873ad3",
+          "description": "Strong quality for this dimension; minor limitations may remain. Whether assertions are based on reliable, verified, and corroborated data."
         },
         {
           "value": "very-high",
           "expanded": "Very high",
           "numerical_value": 100,
-          "uuid": "6f8ec488-cceb-4e18-b5eb-6c9d00949d8b"
+          "uuid": "6f8ec488-cceb-4e18-b5eb-6c9d00949d8b",
+          "description": "Excellent quality for this dimension; fully or near-fully meets expectations. Whether assertions are based on reliable, verified, and corroborated data."
         }
       ]
     },
@@ -202,31 +217,36 @@
           "value": "very-low",
           "expanded": "Very low",
           "numerical_value": 0,
-          "uuid": "2c13e47c-9ac0-4f24-a2a4-505296da2a6c"
+          "uuid": "2c13e47c-9ac0-4f24-a2a4-505296da2a6c",
+          "description": "Very limited quality for this dimension; significant deficiencies were observed. Whether CTI is delivered with enough lead time for effective action."
         },
         {
           "value": "low",
           "expanded": "Low",
           "numerical_value": 25,
-          "uuid": "b3c3f2b2-c61a-4ccb-8a0a-58124d9a6f85"
+          "uuid": "b3c3f2b2-c61a-4ccb-8a0a-58124d9a6f85",
+          "description": "Below expected quality for this dimension; notable weaknesses remain. Whether CTI is delivered with enough lead time for effective action."
         },
         {
           "value": "moderate",
           "expanded": "Moderate",
           "numerical_value": 50,
-          "uuid": "d335bc11-fffc-478f-8076-3b187b9c4a91"
+          "uuid": "d335bc11-fffc-478f-8076-3b187b9c4a91",
+          "description": "Partially meets expectations for this dimension; acceptable but with clear gaps. Whether CTI is delivered with enough lead time for effective action."
         },
         {
           "value": "high",
           "expanded": "High",
           "numerical_value": 75,
-          "uuid": "92beb810-873f-42cf-a9a3-a216e85ca49a"
+          "uuid": "92beb810-873f-42cf-a9a3-a216e85ca49a",
+          "description": "Strong quality for this dimension; minor limitations may remain. Whether CTI is delivered with enough lead time for effective action."
         },
         {
           "value": "very-high",
           "expanded": "Very high",
           "numerical_value": 100,
-          "uuid": "f4ab1481-4fed-4ea5-ba0d-4623a0e7a5fa"
+          "uuid": "f4ab1481-4fed-4ea5-ba0d-4623a0e7a5fa",
+          "description": "Excellent quality for this dimension; fully or near-fully meets expectations. Whether CTI is delivered with enough lead time for effective action."
         }
       ]
     },
@@ -237,31 +257,36 @@
           "value": "very-low",
           "expanded": "Very low",
           "numerical_value": 0,
-          "uuid": "0ec05c80-dfba-486e-a58e-c5447119f1b7"
+          "uuid": "0ec05c80-dfba-486e-a58e-c5447119f1b7",
+          "description": "Very limited quality for this dimension; significant deficiencies were observed. Whether CTI is understandable, unambiguous, and actionable for intended audiences."
         },
         {
           "value": "low",
           "expanded": "Low",
           "numerical_value": 25,
-          "uuid": "2279ea56-761a-43f6-b647-199b834aa776"
+          "uuid": "2279ea56-761a-43f6-b647-199b834aa776",
+          "description": "Below expected quality for this dimension; notable weaknesses remain. Whether CTI is understandable, unambiguous, and actionable for intended audiences."
         },
         {
           "value": "moderate",
           "expanded": "Moderate",
           "numerical_value": 50,
-          "uuid": "718535c4-efa7-4546-b93b-e9b533a9bfd9"
+          "uuid": "718535c4-efa7-4546-b93b-e9b533a9bfd9",
+          "description": "Partially meets expectations for this dimension; acceptable but with clear gaps. Whether CTI is understandable, unambiguous, and actionable for intended audiences."
         },
         {
           "value": "high",
           "expanded": "High",
           "numerical_value": 75,
-          "uuid": "e1ca5e3f-bad3-45c7-8556-24ede6652656"
+          "uuid": "e1ca5e3f-bad3-45c7-8556-24ede6652656",
+          "description": "Strong quality for this dimension; minor limitations may remain. Whether CTI is understandable, unambiguous, and actionable for intended audiences."
         },
         {
           "value": "very-high",
           "expanded": "Very high",
           "numerical_value": 100,
-          "uuid": "840866db-8e56-4b41-bebf-db18b12c2b28"
+          "uuid": "840866db-8e56-4b41-bebf-db18b12c2b28",
+          "description": "Excellent quality for this dimension; fully or near-fully meets expectations. Whether CTI is understandable, unambiguous, and actionable for intended audiences."
         }
       ]
     },
@@ -272,31 +297,36 @@
           "value": "very-low",
           "expanded": "Very low",
           "numerical_value": 0,
-          "uuid": "e1efcaa5-4562-48fa-8ddb-89e7785b12ea"
+          "uuid": "e1efcaa5-4562-48fa-8ddb-89e7785b12ea",
+          "description": "Very limited quality for this dimension; significant deficiencies were observed. Whether CTI contains concrete details (what, where, when, who, how) needed to act."
         },
         {
           "value": "low",
           "expanded": "Low",
           "numerical_value": 25,
-          "uuid": "76c8f204-2218-4f64-83ea-2fe4b8de38ef"
+          "uuid": "76c8f204-2218-4f64-83ea-2fe4b8de38ef",
+          "description": "Below expected quality for this dimension; notable weaknesses remain. Whether CTI contains concrete details (what, where, when, who, how) needed to act."
         },
         {
           "value": "moderate",
           "expanded": "Moderate",
           "numerical_value": 50,
-          "uuid": "a98d664e-996d-4973-a4b6-45ef9f8df7ac"
+          "uuid": "a98d664e-996d-4973-a4b6-45ef9f8df7ac",
+          "description": "Partially meets expectations for this dimension; acceptable but with clear gaps. Whether CTI contains concrete details (what, where, when, who, how) needed to act."
         },
         {
           "value": "high",
           "expanded": "High",
           "numerical_value": 75,
-          "uuid": "25a3aa66-779e-426d-b016-01653fe56f89"
+          "uuid": "25a3aa66-779e-426d-b016-01653fe56f89",
+          "description": "Strong quality for this dimension; minor limitations may remain. Whether CTI contains concrete details (what, where, when, who, how) needed to act."
         },
         {
           "value": "very-high",
           "expanded": "Very high",
           "numerical_value": 100,
-          "uuid": "0a062f3d-3d7c-43f9-8c2f-e7ed3d466d6c"
+          "uuid": "0a062f3d-3d7c-43f9-8c2f-e7ed3d466d6c",
+          "description": "Excellent quality for this dimension; fully or near-fully meets expectations. Whether CTI contains concrete details (what, where, when, who, how) needed to act."
         }
       ]
     },
@@ -307,31 +337,36 @@
           "value": "very-low",
           "expanded": "Very low",
           "numerical_value": 0,
-          "uuid": "b5c3b394-dd65-4046-acbd-905756eb5c58"
+          "uuid": "b5c3b394-dd65-4046-acbd-905756eb5c58",
+          "description": "Very limited quality for this dimension; significant deficiencies were observed. Practical utility of CTI for operations, detection, response, or strategic decisions."
         },
         {
           "value": "low",
           "expanded": "Low",
           "numerical_value": 25,
-          "uuid": "99fc1436-04ae-43b9-a493-e7b1d9b385b6"
+          "uuid": "99fc1436-04ae-43b9-a493-e7b1d9b385b6",
+          "description": "Below expected quality for this dimension; notable weaknesses remain. Practical utility of CTI for operations, detection, response, or strategic decisions."
         },
         {
           "value": "moderate",
           "expanded": "Moderate",
           "numerical_value": 50,
-          "uuid": "7d11ecf5-efe0-461b-b0fe-742da25b2358"
+          "uuid": "7d11ecf5-efe0-461b-b0fe-742da25b2358",
+          "description": "Partially meets expectations for this dimension; acceptable but with clear gaps. Practical utility of CTI for operations, detection, response, or strategic decisions."
         },
         {
           "value": "high",
           "expanded": "High",
           "numerical_value": 75,
-          "uuid": "2de05f07-069f-4869-b42f-1708893ee568"
+          "uuid": "2de05f07-069f-4869-b42f-1708893ee568",
+          "description": "Strong quality for this dimension; minor limitations may remain. Practical utility of CTI for operations, detection, response, or strategic decisions."
         },
         {
           "value": "very-high",
           "expanded": "Very high",
           "numerical_value": 100,
-          "uuid": "49377759-ba5c-4975-a0d1-dccc5b5bdd3c"
+          "uuid": "49377759-ba5c-4975-a0d1-dccc5b5bdd3c",
+          "description": "Excellent quality for this dimension; fully or near-fully meets expectations. Practical utility of CTI for operations, detection, response, or strategic decisions."
         }
       ]
     },
@@ -342,31 +377,36 @@
           "value": "very-low",
           "expanded": "Very low",
           "numerical_value": 0,
-          "uuid": "b12231a8-330f-406b-a62c-44c96cf6be57"
+          "uuid": "b12231a8-330f-406b-a62c-44c96cf6be57",
+          "description": "Very limited quality for this dimension; significant deficiencies were observed. Conformance of CTI artifacts to expected schema/syntax (e.g., STIX/MISP structures)."
         },
         {
           "value": "low",
           "expanded": "Low",
           "numerical_value": 25,
-          "uuid": "0923d55e-dbbe-46a5-bb40-366ec9fad559"
+          "uuid": "0923d55e-dbbe-46a5-bb40-366ec9fad559",
+          "description": "Below expected quality for this dimension; notable weaknesses remain. Conformance of CTI artifacts to expected schema/syntax (e.g., STIX/MISP structures)."
         },
         {
           "value": "moderate",
           "expanded": "Moderate",
           "numerical_value": 50,
-          "uuid": "3122228c-12fe-4a55-8393-17d19eb2bced"
+          "uuid": "3122228c-12fe-4a55-8393-17d19eb2bced",
+          "description": "Partially meets expectations for this dimension; acceptable but with clear gaps. Conformance of CTI artifacts to expected schema/syntax (e.g., STIX/MISP structures)."
         },
         {
           "value": "high",
           "expanded": "High",
           "numerical_value": 75,
-          "uuid": "fb9aefc2-860c-4a7f-87c4-61daba5d61dd"
+          "uuid": "fb9aefc2-860c-4a7f-87c4-61daba5d61dd",
+          "description": "Strong quality for this dimension; minor limitations may remain. Conformance of CTI artifacts to expected schema/syntax (e.g., STIX/MISP structures)."
         },
         {
           "value": "very-high",
           "expanded": "Very high",
           "numerical_value": 100,
-          "uuid": "8b9f3ce8-30f6-4b5c-8992-899aedb1a6f5"
+          "uuid": "8b9f3ce8-30f6-4b5c-8992-899aedb1a6f5",
+          "description": "Excellent quality for this dimension; fully or near-fully meets expectations. Conformance of CTI artifacts to expected schema/syntax (e.g., STIX/MISP structures)."
         }
       ]
     },
@@ -377,31 +417,36 @@
           "value": "very-low",
           "expanded": "Very low",
           "numerical_value": 0,
-          "uuid": "7ca279d8-809c-4029-bdd5-c2fab201f862"
+          "uuid": "7ca279d8-809c-4029-bdd5-c2fab201f862",
+          "description": "Very limited quality for this dimension; significant deficiencies were observed. How faithfully intelligence survives format conversion (e.g., MISP to STIX and back)."
         },
         {
           "value": "low",
           "expanded": "Low",
           "numerical_value": 25,
-          "uuid": "d0d97b5c-fc44-44df-9929-27b3bf6ca7f5"
+          "uuid": "d0d97b5c-fc44-44df-9929-27b3bf6ca7f5",
+          "description": "Below expected quality for this dimension; notable weaknesses remain. How faithfully intelligence survives format conversion (e.g., MISP to STIX and back)."
         },
         {
           "value": "moderate",
           "expanded": "Moderate",
           "numerical_value": 50,
-          "uuid": "724f78a7-7bb5-45bc-b0f4-f01abb9283d0"
+          "uuid": "724f78a7-7bb5-45bc-b0f4-f01abb9283d0",
+          "description": "Partially meets expectations for this dimension; acceptable but with clear gaps. How faithfully intelligence survives format conversion (e.g., MISP to STIX and back)."
         },
         {
           "value": "high",
           "expanded": "High",
           "numerical_value": 75,
-          "uuid": "a3d88da1-9df5-4f41-b2ca-6a7fdd84c2dc"
+          "uuid": "a3d88da1-9df5-4f41-b2ca-6a7fdd84c2dc",
+          "description": "Strong quality for this dimension; minor limitations may remain. How faithfully intelligence survives format conversion (e.g., MISP to STIX and back)."
         },
         {
           "value": "very-high",
           "expanded": "Very high",
           "numerical_value": 100,
-          "uuid": "3098e418-10b5-44ae-ac60-f6bd24829ade"
+          "uuid": "3098e418-10b5-44ae-ac60-f6bd24829ade",
+          "description": "Excellent quality for this dimension; fully or near-fully meets expectations. How faithfully intelligence survives format conversion (e.g., MISP to STIX and back)."
         }
       ]
     },
@@ -412,31 +457,36 @@
           "value": "very-low",
           "expanded": "Very low",
           "numerical_value": 0,
-          "uuid": "35a05b9d-3d79-499d-8c4a-8f5a060d9e5d"
+          "uuid": "35a05b9d-3d79-499d-8c4a-8f5a060d9e5d",
+          "description": "Very limited quality for this dimension; significant deficiencies were observed. Reliability of primary and secondary sources underpinning the CTI."
         },
         {
           "value": "low",
           "expanded": "Low",
           "numerical_value": 25,
-          "uuid": "0db4a77b-0602-4ab8-a813-ac51a2c38a8e"
+          "uuid": "0db4a77b-0602-4ab8-a813-ac51a2c38a8e",
+          "description": "Below expected quality for this dimension; notable weaknesses remain. Reliability of primary and secondary sources underpinning the CTI."
         },
         {
           "value": "moderate",
           "expanded": "Moderate",
           "numerical_value": 50,
-          "uuid": "3f1994dd-0a98-44a7-8cd1-917be5921c4c"
+          "uuid": "3f1994dd-0a98-44a7-8cd1-917be5921c4c",
+          "description": "Partially meets expectations for this dimension; acceptable but with clear gaps. Reliability of primary and secondary sources underpinning the CTI."
         },
         {
           "value": "high",
           "expanded": "High",
           "numerical_value": 75,
-          "uuid": "ed2fba05-d8ab-44d1-8fcf-81a3f2326130"
+          "uuid": "ed2fba05-d8ab-44d1-8fcf-81a3f2326130",
+          "description": "Strong quality for this dimension; minor limitations may remain. Reliability of primary and secondary sources underpinning the CTI."
         },
         {
           "value": "very-high",
           "expanded": "Very high",
           "numerical_value": 100,
-          "uuid": "1d57ec60-2821-4f21-a6c3-7fe17bb73612"
+          "uuid": "1d57ec60-2821-4f21-a6c3-7fe17bb73612",
+          "description": "Excellent quality for this dimension; fully or near-fully meets expectations. Reliability of primary and secondary sources underpinning the CTI."
         }
       ]
     },
@@ -447,31 +497,36 @@
           "value": "very-low",
           "expanded": "Very low",
           "numerical_value": 0,
-          "uuid": "4b709dec-7414-47bc-97b2-730295afc971"
+          "uuid": "4b709dec-7414-47bc-97b2-730295afc971",
+          "description": "Very limited quality for this dimension; significant deficiencies were observed. Strength and sufficiency of supporting evidence for the claims."
         },
         {
           "value": "low",
           "expanded": "Low",
           "numerical_value": 25,
-          "uuid": "77f09051-6fb7-4425-819d-380d213bb770"
+          "uuid": "77f09051-6fb7-4425-819d-380d213bb770",
+          "description": "Below expected quality for this dimension; notable weaknesses remain. Strength and sufficiency of supporting evidence for the claims."
         },
         {
           "value": "moderate",
           "expanded": "Moderate",
           "numerical_value": 50,
-          "uuid": "e07e90b9-d824-4b8d-ac20-fd4c52b8af54"
+          "uuid": "e07e90b9-d824-4b8d-ac20-fd4c52b8af54",
+          "description": "Partially meets expectations for this dimension; acceptable but with clear gaps. Strength and sufficiency of supporting evidence for the claims."
         },
         {
           "value": "high",
           "expanded": "High",
           "numerical_value": 75,
-          "uuid": "7d860416-8123-4471-a1de-5f78fa149c46"
+          "uuid": "7d860416-8123-4471-a1de-5f78fa149c46",
+          "description": "Strong quality for this dimension; minor limitations may remain. Strength and sufficiency of supporting evidence for the claims."
         },
         {
           "value": "very-high",
           "expanded": "Very high",
           "numerical_value": 100,
-          "uuid": "4ab016de-464e-4a25-bb47-cbbbd2cf24a8"
+          "uuid": "4ab016de-464e-4a25-bb47-cbbbd2cf24a8",
+          "description": "Excellent quality for this dimension; fully or near-fully meets expectations. Strength and sufficiency of supporting evidence for the claims."
         }
       ]
     },
@@ -482,31 +537,36 @@
           "value": "very-low",
           "expanded": "Very low",
           "numerical_value": 0,
-          "uuid": "b569eedc-9dc6-4dc1-bf28-a4c9ca878b52"
+          "uuid": "b569eedc-9dc6-4dc1-bf28-a4c9ca878b52",
+          "description": "Very limited quality for this dimension; significant deficiencies were observed. Analyst or reviewer confidence in the CTI judgments."
         },
         {
           "value": "low",
           "expanded": "Low",
           "numerical_value": 25,
-          "uuid": "327e5669-0edf-46a4-bc15-fccbff70a757"
+          "uuid": "327e5669-0edf-46a4-bc15-fccbff70a757",
+          "description": "Below expected quality for this dimension; notable weaknesses remain. Analyst or reviewer confidence in the CTI judgments."
         },
         {
           "value": "moderate",
           "expanded": "Moderate",
           "numerical_value": 50,
-          "uuid": "668ddd74-8c94-4da8-b939-cd4c1c7f903d"
+          "uuid": "668ddd74-8c94-4da8-b939-cd4c1c7f903d",
+          "description": "Partially meets expectations for this dimension; acceptable but with clear gaps. Analyst or reviewer confidence in the CTI judgments."
         },
         {
           "value": "high",
           "expanded": "High",
           "numerical_value": 75,
-          "uuid": "2e4d78b8-bcfc-49da-8e51-9c6d11a8e4fb"
+          "uuid": "2e4d78b8-bcfc-49da-8e51-9c6d11a8e4fb",
+          "description": "Strong quality for this dimension; minor limitations may remain. Analyst or reviewer confidence in the CTI judgments."
         },
         {
           "value": "very-high",
           "expanded": "Very high",
           "numerical_value": 100,
-          "uuid": "91f8d6e0-9d65-4752-9cb7-62a259e2af5b"
+          "uuid": "91f8d6e0-9d65-4752-9cb7-62a259e2af5b",
+          "description": "Excellent quality for this dimension; fully or near-fully meets expectations. Analyst or reviewer confidence in the CTI judgments."
         }
       ]
     }


### PR DESCRIPTION
### Motivation
- Provide a standardized MISP taxonomy to record reviewer/analyst evaluations of CTI quality and conversion fidelity for workflows like MISP↔STIX exchange and CTI Transmute. 
- Capture core assessment dimensions (relevance, accuracy, timeliness, clarity, specificity, usefulness) and conversion/format checks (format validity, conversion fidelity) plus supporting reviewer signals (source reliability, evidence strength, confidence, overall score).

### Description
- Added a new taxonomy file at `cti-evaluation/machinetag.json` defining the `cti-evaluation` namespace with version `1` and a descriptive summary. 
- Introduced 12 exclusive predicates: `overall-score`, `relevance`, `accuracy`, `timeliness`, `clarity`, `specificity`, `usefulness`, `format-validity`, `conversion-fidelity`, `source-reliability`, `evidence-strength`, and `confidence` each with a UUID. 
- Implemented a uniform 5-level scoring model for each predicate using values `very-low`, `low`, `moderate`, `high`, `very-high` and `numerical_value` mapping `0, 25, 50, 75, 100` to simplify aggregation and numeric scoring. 
- Updated `MANIFEST.json` to register the new `cti-evaluation` taxonomy and keep the taxonomy list sorted by name. 

### Testing
- Validated the new taxonomy JSON with `python -m json.tool cti-evaluation/machinetag.json`, which succeeded. 
- Validated the updated manifest with `python -m json.tool MANIFEST.json`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1592f3d92c8324b025406249fa74e3)