### PR TITLE
dark-web: add requested structure tags and refine predicate descriptions

### DIFF
--- a/dark-web/machinetag.json
+++ b/dark-web/machinetag.json
@@ -2,35 +2,35 @@
   "namespace": "dark-web",
   "expanded": "Dark Web",
   "description": "Criminal motivation and content detection the dark web: A categorisation model for law enforcement. ref: Janis Dalins, Campbell Wilson, Mark Carman. Taxonomy updated by MISP Project and extended by the JRC (Joint Research Centre) of the European Commission.",
-  "version": 10,
+  "version": 11,
   "predicates": [
     {
       "value": "topic",
-      "description": "Topic associated with the materials tagged",
+      "description": "Primary topical category of the observed dark-web material or discussion.",
       "expanded": "Topic",
       "uuid": "99c3043d-75c9-5033-bd26-c28da3790599"
     },
     {
       "value": "motivation",
-      "description": "Motivation with the materials tagged",
+      "description": "Observed intent or purpose of the service, content, or actor activity.",
       "expanded": "Motivation",
       "uuid": "0cf412bf-5d22-5777-a3f3-e8997b26adf4"
     },
     {
       "value": "structure",
-      "description": "Structure of the materials tagged",
+      "description": "Page or post archetype describing how information is presented on the service.",
       "expanded": "Structure",
       "uuid": "b35ff672-d3af-532b-bd4f-c540297a0a92"
     },
     {
       "value": "service",
-      "description": "Information related to an Dark-Web service",
+      "description": "Technical and discovery metadata used to identify and locate the dark-web service.",
       "expanded": "Service",
       "uuid": "177a84c2-adbf-5d9c-9ddb-5b3da021b80a"
     },
     {
       "value": "content",
-      "description": "Identifiable entities and information contained in a Dark-Web service",
+      "description": "Extracted artifacts and entities identified directly within the service content.",
       "expanded": "Content",
       "uuid": "0dda2a15-f88c-5cb4-9eea-4ab98ae78586"
     }
@@ -386,22 +386,16 @@
       "predicate": "structure",
       "entry": [
         {
-          "value": "incomplete",
-          "expanded": "incomplete",
-          "description": "Websites and pages that are unable to load completely properly",
-          "uuid": "163fc4a7-6dc9-5e76-8858-15ee8dc3bec9"
-        },
-        {
           "value": "captcha",
           "expanded": "captcha",
           "description": "Captchas and solvers elements",
           "uuid": "1a335beb-c479-5042-87e6-403e045f8c00"
         },
         {
-          "value": "login-forms",
-          "expanded": "loginForms",
-          "description": "Authentication pages, login page, login forms that block access to an internal part of a website.",
-          "uuid": "b6913de4-0184-5261-9c64-9f0d52503c7b"
+          "value": "carding",
+          "expanded": "Carding",
+          "description": "Related to selling, fraud, or illegal activities involving credit cards.",
+          "uuid": "1a1ed113-88fc-550f-af93-f73843dc2ece"
         },
         {
           "value": "contact-forms",
@@ -410,16 +404,52 @@
           "uuid": "8e3e6ec4-711b-504a-8772-3c01782f480f"
         },
         {
+          "value": "creds-dumps",
+          "expanded": "CredsDumps",
+          "description": "Related to credential leaks published for download or sharing.",
+          "uuid": "2135f750-4238-59d8-8639-6d2e47244026"
+        },
+        {
+          "value": "ddos",
+          "expanded": "DDoS",
+          "description": "Discussion of DDoS activities, attack claims, or sale of DDoS tools/services.",
+          "uuid": "9d4f3366-1a2b-5574-8fcc-aa3d4aee0caa"
+        },
+        {
           "value": "encryption-keys",
           "expanded": "encryptionKeys",
           "description": "e.g. PGP Keys, passwords, ...",
           "uuid": "04ef6db9-f206-5e65-8b55-f9597cc5ee82"
         },
         {
-          "value": "police-notice",
-          "expanded": "policeNotice",
-          "description": "Closed websites, with police-equivalent banners",
-          "uuid": "765d98a5-c65f-5bf1-aca0-11ae735913ec"
+          "value": "hacking-claim",
+          "expanded": "Hacking_claim",
+          "description": "Claims by threat actors about website compromises or pride in breaching systems.",
+          "uuid": "cc471da8-07e5-59d6-9f22-52d8ef70fc17"
+        },
+        {
+          "value": "hosting",
+          "expanded": "Hosting",
+          "description": "Content about AWS, Azure, DigitalOcean, or related hosting accounts, often offered at discounted prices.",
+          "uuid": "e8d45e28-6902-5163-b6b9-d99248c7b74e"
+        },
+        {
+          "value": "incomplete",
+          "expanded": "incomplete",
+          "description": "Websites and pages that are unable to load completely properly",
+          "uuid": "163fc4a7-6dc9-5e76-8858-15ee8dc3bec9"
+        },
+        {
+          "value": "law-enforcement",
+          "expanded": "Law_enforcement",
+          "description": "Related to channels of police/government and law-enforcement actions against threat actors.",
+          "uuid": "aa10c646-bbd4-5538-871a-30788cd45e5f"
+        },
+        {
+          "value": "leaks",
+          "expanded": "Leaks",
+          "description": "Company leak disclosures after hacks, such as SQL database dumps.",
+          "uuid": "8ae908ee-41e8-50b3-af66-392380e4f94e"
         },
         {
           "value": "legal-statement",
@@ -428,16 +458,22 @@
           "uuid": "03ba3686-4c49-5e0f-b56a-8b730955e344"
         },
         {
-          "value": "test",
-          "expanded": "test",
-          "description": "Test websites without any real consequences or effects",
-          "uuid": "11044e87-a985-5c2a-a865-6531f46a5d6d"
+          "value": "login-forms",
+          "expanded": "loginForms",
+          "description": "Authentication pages, login page, login forms that block access to an internal part of a website.",
+          "uuid": "b6913de4-0184-5261-9c64-9f0d52503c7b"
         },
         {
-          "value": "videos",
-          "expanded": "videos",
-          "description": "Videos and streaming",
-          "uuid": "c8e7e0c9-ce42-56c9-bf86-0e7997e4212a"
+          "value": "police-notice",
+          "expanded": "policeNotice",
+          "description": "Closed websites, with police-equivalent banners",
+          "uuid": "765d98a5-c65f-5bf1-aca0-11ae735913ec"
+        },
+        {
+          "value": "ponzi-financial",
+          "expanded": "Ponzi/Financial",
+          "description": "Related to financial-gain schemes, investment fraud, or Ponzi-style operations.",
+          "uuid": "c989c30f-e0b5-55e3-8c92-d74afd6b03e9"
         },
         {
           "value": "ransomware-post",
@@ -446,10 +482,28 @@
           "uuid": "8adc9bef-350a-573e-bf09-b002981de97a"
         },
         {
+          "value": "test",
+          "expanded": "test",
+          "description": "Test websites without any real consequences or effects",
+          "uuid": "11044e87-a985-5c2a-a865-6531f46a5d6d"
+        },
+        {
+          "value": "testimonial",
+          "expanded": "Testimonial",
+          "description": "Evidence of payments or proof that a service is legitimate; excludes greetings or shout-outs to groups.",
+          "uuid": "f84fe9d9-60a6-586c-92a6-2b3c16a7d651"
+        },
+        {
           "value": "unclear",
           "expanded": "unclear",
           "description": "Unable to completely establish structure of material.",
           "uuid": "9f67fb3a-1599-5fd6-b0d1-cc2a272246ce"
+        },
+        {
+          "value": "videos",
+          "expanded": "videos",
+          "description": "Videos and streaming",
+          "uuid": "c8e7e0c9-ce42-56c9-bf86-0e7997e4212a"
         }
       ]
     },


### PR DESCRIPTION
### Motivation
- Ensure the dark-web taxonomy includes explicit tags for common criminal and operational topics that analysts look for (law-enforcement, carding, hacking-claim, creds-dumps, leaks, ddos, ponzi-financial, testimonial, hosting). 
- Make predicate metadata clearer so taggers and automated systems can apply the taxonomy more consistently. 
- Bump the taxonomy version to indicate a non‑backward compatible set of additions and description changes.

### Description
- Updated the descriptions for all predicates to clearer, action-oriented text for `topic`, `motivation`, `structure`, `service`, and `content`.
- Added the following entries under the `structure` predicate with provided expanded names and descriptions: `law-enforcement (Law_enforcement)`, `carding (Carding)`, `hacking-claim (Hacking_claim)`, `creds-dumps (CredsDumps)`, `leaks (Leaks)`, `ddos (DDoS)`, `ponzi-financial (Ponzi/Financial)`, `testimonial (Testimonial)`, and `hosting (Hosting)`. 
- Kept `structure` entries sorted for consistency and incremented the taxonomy `version` value to `11`.
- Wrote deterministic UUIDs for new entries and preserved existing entry ordering where possible.

### Testing
- Verified JSON syntax and well-formedness with `python -m json.tool dark-web/machinetag.json`, which succeeded. 
- Ran a small Python inspection script to enumerate predicates and confirm all new `structure` entries are present, which produced the expected output. 
- Performed file-level validation to ensure only `dark-web/machinetag.json` was modified and the file remains valid JSON, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15a1234db0832481b17bf7f413a0c5)