### PR TITLE
Fix METEORSTORM Attack Path UUID

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -905,5 +905,5 @@
     }
   ],
   "url": "https://raw.githubusercontent.com/MISP/misp-taxonomies/main/",
-  "version": "20260603"
+  "version": "20260604"
 }

--- a/meteorstorm/machinetag.json
+++ b/meteorstorm/machinetag.json
@@ -207,7 +207,7 @@
           "value": "AN-ATT",
           "expanded": "Attack Path",
           "description": "Confirmed attack path for a converged space system.",
-          "uuid": "fedcba98-7654-3210-fedc-ba9876543210"
+          "uuid": "f65b211d-f44d-552a-ad2d-c94293036ce7"
         },
         {
           "value": "AN-IOC",


### PR DESCRIPTION
This fixes the METEORSTORM Attack Path entry UUID.

The previous UUID was rejected by PyTaxonomies because it does not parse as one of the accepted UUID versions: 1, 4, or 5.

The replacement UUID is a valid UUID v5:
f65b211d-f44d-552a-ad2d-c94293036ce7