### PR TITLE
Add AVIDML taxonomies and update MANIFEST

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -114,6 +114,31 @@
       "version": 1
     },
     {
+      "description": "AVIDML import of the AVID effect taxonomy. The domains, categories, and subcategories in this view provide a risk surface for the AI artifact being evaluated, whether it is a dataset, model, or whole system.",
+      "name": "avidml-effect",
+      "version": 1
+    },
+    {
+      "description": "AVIDML import of a structured taxonomy for Large Language Model (LLM) adversarial threats, including prompt injection, role override, execution hijack, information disclosure, output manipulation, and multi-agent exploitation, derived from the InjectLab project.",
+      "name": "avidml-injectlab-llm-attck",
+      "version": 1
+    },
+    {
+      "description": "AVIDML import of the AVID lifecycle taxonomy, adopting the CRISP-DM lifecycle as a starting point and mapping development stages for datasets, models, and systems within the AI ecosystem.",
+      "name": "avidml-lifecycle",
+      "version": 1
+    },
+    {
+      "description": "AVIDML import of the Risk Cards framework of Derczynski et al., Assessing Language Model Deployment with Risk Cards, arXiv 2303.1819, 2023.",
+      "name": "avidml-risk-cards",
+      "version": 1
+    },
+    {
+      "description": "AVIDML import of the Operational Design Domain taxonomy from Heidy Khlaaf's publication 'Toward Comprehensive Risk Assessments and Assurance of AI-Based Systems'.",
+      "name": "avidml-trail-of-bits-odds",
+      "version": 1
+    },
+    {
       "description": "Custom taxonomy for types of binary file.",
       "name": "binary-class",
       "version": 2
@@ -905,5 +930,5 @@
     }
   ],
   "url": "https://raw.githubusercontent.com/MISP/misp-taxonomies/main/",
-  "version": "20260610"
+  "version": "20260616"
 }

--- a/avidml-effect/machinetag.json
+++ b/avidml-effect/machinetag.json
@@ -1,0 +1,334 @@
+{
+  "namespace": "avidml-effect",
+  "description": "AVIDML import of the AVID effect taxonomy. The domains, categories, and subcategories in this view provide a risk surface for the AI artifact being evaluated, whether it is a dataset, model, or whole system.",
+  "refs": [
+    "https://github.com/avidml/avid-schema/tree/main/taxonomy"
+  ],
+  "version": 1,
+  "predicates": [
+    {
+      "value": "security",
+      "expanded": "Security",
+      "description": "Cybersecurity vulnerabilities as translated specifically for the AI ecosystem.",
+      "uuid": "b8dcfbd4-dc32-4aa5-812b-729b10f16192"
+    },
+    {
+      "value": "ethics",
+      "expanded": "Ethics",
+      "description": "Considerations of ethics, fairness, and harm as they are represented throughout the AI ecosystem.",
+      "uuid": "c6e1e19d-984e-4add-9edc-6bb7c6b02bdd"
+    },
+    {
+      "value": "performance",
+      "expanded": "Performance",
+      "description": "Contains both the model's performance (Accuracy, Precision, etc.) and system performance (Safety, Privacy, etc.).",
+      "uuid": "64d01fbc-8c88-4998-9b02-511640e5a139"
+    }
+  ],
+  "values": [
+    {
+      "predicate": "security",
+      "entry": [
+        {
+          "value": "S0100",
+          "expanded": "Software Vulnerability",
+          "description": "Vulnerability in system around model—a traditional software vulnerability",
+          "uuid": "06b2986f-2696-4086-bf6d-54bd334d3382"
+        },
+        {
+          "value": "S0200",
+          "expanded": "Supply Chain Compromise",
+          "description": "Compromising development components of a ML model, e.g. data, model, hardware, and software stack.",
+          "uuid": "76613726-13c2-435b-83ee-b418db8b2583"
+        },
+        {
+          "value": "S0201",
+          "expanded": "Model Compromise",
+          "description": "An infected model file.",
+          "uuid": "163f91db-ff54-4793-8b82-142d97006f3d"
+        },
+        {
+          "value": "S0202",
+          "expanded": "Software Compromise",
+          "description": "An upstream dependency compromise.",
+          "uuid": "3bc77177-2e1a-4896-adc5-cbedc4887cfb"
+        },
+        {
+          "value": "S0300",
+          "expanded": "Over-permissive API",
+          "description": "Unintended information leakage through API.",
+          "uuid": "eaa99463-f2e0-4242-b273-b74718109b57"
+        },
+        {
+          "value": "S0301",
+          "expanded": "Information Leak",
+          "description": "Cloud Model API leaks more information than it needs to.",
+          "uuid": "0cf4c2f5-4f36-4fc4-9328-fef66f4e51e7"
+        },
+        {
+          "value": "S0302",
+          "expanded": "Excessive Queries",
+          "description": "Cloud Model API isn’t sufficiently rate limited.",
+          "uuid": "96b8a4b5-0d94-47a8-8fd2-c90e838578b9"
+        },
+        {
+          "value": "S0400",
+          "expanded": "Model Bypass",
+          "description": "Intentionally try to make a model perform poorly.",
+          "uuid": "e66eb99b-0f2d-47f8-a145-2d6c3b87b439"
+        },
+        {
+          "value": "S0401",
+          "expanded": "Bad Features",
+          "description": "The model uses features that are easily gamed by the attacker.",
+          "uuid": "8b2068b8-7d14-47ad-b013-83f932619950"
+        },
+        {
+          "value": "S0402",
+          "expanded": "Insufficient Training Data",
+          "description": "The bypass is not represented in the training data.",
+          "uuid": "a8651f1d-a009-402c-9884-06cd0c1a645c"
+        },
+        {
+          "value": "S0403",
+          "expanded": "Adversarial Example",
+          "description": "Input data points intentionally supplied to draw mispredictions.",
+          "uuid": "4d40f748-72de-4ba9-bd2b-9fb999bf8f06"
+        },
+        {
+          "value": "S0500",
+          "expanded": "Exfiltration",
+          "description": "Directly or indirectly exfiltrate ML artifacts.",
+          "uuid": "c85b715c-8d7b-4f46-b33b-83b108f067b1"
+        },
+        {
+          "value": "S0501",
+          "expanded": "Model inversion",
+          "description": "Reconstruct training data through strategic queries.",
+          "uuid": "ec853c4e-ed79-4518-9612-3502e10a8fbb"
+        },
+        {
+          "value": "S0502",
+          "expanded": "Model theft",
+          "description": "Extract model functionality through strategic queries.",
+          "uuid": "fdc8eb69-02fd-4b2d-89ff-eb4e04f31687"
+        },
+        {
+          "value": "S0600",
+          "expanded": "Data Poisoning",
+          "description": "Usage of poisoned data in the ML pipeline.",
+          "uuid": "201700d6-77e4-4511-9e28-75206d710cd9"
+        },
+        {
+          "value": "S0601",
+          "expanded": "Ingest Poisoning",
+          "description": "Attackers inject poisoned data into the ingest pipeline.",
+          "uuid": "62226b72-e412-4fac-8c1c-461c267b2117"
+        }
+      ]
+    },
+    {
+      "predicate": "ethics",
+      "entry": [
+        {
+          "value": "E0100",
+          "expanded": "Bias and Discrimination",
+          "description": "Concerns of algorithms propagating societal bias.",
+          "uuid": "ac5f8691-f4e7-407d-b729-f489b6ab87eb"
+        },
+        {
+          "value": "E0101",
+          "expanded": "Group fairness",
+          "description": "Fairness towards specific groups of people.",
+          "uuid": "8662d6a1-7c5f-45ee-aad2-cd507ebd416b"
+        },
+        {
+          "value": "E0102",
+          "expanded": "Individual Fairness",
+          "description": "Fairness in treating similar individuals.",
+          "uuid": "8bdeae57-c245-4fd5-992b-a1ed6855ee83"
+        },
+        {
+          "value": "E0200",
+          "expanded": "Explainability",
+          "description": "Ability to explain decisions made by AI.",
+          "uuid": "f901179a-7238-4b5e-a271-d17a0a5ae21b"
+        },
+        {
+          "value": "E0201",
+          "expanded": "Global Explanations",
+          "description": "Explain overall functionality and performance of the model.",
+          "uuid": "7191319e-4594-45e5-a916-6ea5dd0eb46f"
+        },
+        {
+          "value": "E0202",
+          "expanded": "Local Explanations",
+          "description": "Explain specific decisions of a model.",
+          "uuid": "f4091fd1-cecc-4275-a5d7-af26029b9394"
+        },
+        {
+          "value": "E0300",
+          "expanded": "User Actions",
+          "description": "Perpetuating/causing/being affected by negative user actions.",
+          "uuid": "7d88d3a8-dc21-45ec-9220-d0a25fd49a45"
+        },
+        {
+          "value": "E0301",
+          "expanded": "Toxicity",
+          "description": "Users hostile towards other users.",
+          "uuid": "a2a56113-cfe0-41ee-bd68-e2b9136fe503"
+        },
+        {
+          "value": "E0302",
+          "expanded": "Polarization and Exclusion",
+          "description": "User behavior skewed in a significant direction.",
+          "uuid": "f62ed7a6-286e-40a3-a801-b425f463bb57"
+        },
+        {
+          "value": "E0400",
+          "expanded": "Misinformation",
+          "description": "Perpetuating or causing the spread of falsehoods.",
+          "uuid": "e5a3cac9-69c2-458c-86e6-d75d8f932176"
+        },
+        {
+          "value": "E0401",
+          "expanded": "Deliberative Misinformation",
+          "description": "Intentional spreading of false information to affect others (i.e. disinformation).",
+          "uuid": "c4ad7ada-91cb-4640-8f21-3dda6cbbaf07"
+        },
+        {
+          "value": "E0100",
+          "expanded": "Generative Disinformation",
+          "description": "Generated algorithmically (e.g. Deep Fakes).",
+          "uuid": "9f7be163-fb5f-48ef-98ba-9647ee697e50"
+        }
+      ]
+    },
+    {
+      "predicate": "performance",
+      "entry": [
+        {
+          "value": "P0100",
+          "expanded": "Data Issues",
+          "description": "Problems arising due to faults in the data pipeline.",
+          "uuid": "6852a604-c28a-4d34-98db-f2b65049f88b"
+        },
+        {
+          "value": "P0101",
+          "expanded": "Data Drift",
+          "description": "Input feature distribution has drifted.",
+          "uuid": "e0e50b1a-3437-4261-9f95-498f0e65ba75"
+        },
+        {
+          "value": "P0102",
+          "expanded": "Concept Drift",
+          "description": "Output feature or label distribution has drifted.",
+          "uuid": "11e583e3-2028-4330-a99e-88b0303dea37"
+        },
+        {
+          "value": "P0103",
+          "expanded": "Data Entanglement",
+          "description": "Cases of spurious correlation and proxy features.",
+          "uuid": "ac7506c9-8ca6-41f7-b90f-219f28e7cdba"
+        },
+        {
+          "value": "P0104",
+          "expanded": "Data Quality Issues",
+          "description": "Missing or low-quality features in training and validation data.",
+          "uuid": "ff2315f1-921d-4b0c-ac15-3ff74c9e90f9"
+        },
+        {
+          "value": "P0105",
+          "expanded": "Feedback Loops",
+          "description": "Unaccounted for effects of an AI affecting future data collection.",
+          "uuid": "0cf789df-e605-4c26-ae34-d16778c4d66b"
+        },
+        {
+          "value": "P0200",
+          "expanded": "Model Issues",
+          "description": "Ability for the AI to perform as intended.",
+          "uuid": "3da89c41-d89b-4cb6-baff-1383186072a8"
+        },
+        {
+          "value": "P0201",
+          "expanded": "Resilience & Stability",
+          "description": "Ability for outputs to not be affected by small change in inputs.",
+          "uuid": "af8a6b9a-21af-4f05-a62a-611d54ae9411"
+        },
+        {
+          "value": "P0202",
+          "expanded": "OOD Generalization",
+          "description": "Model performance deteriorates on data not seen in training (e.g Out of Distribution).",
+          "uuid": "9e2b17a6-4472-4bdf-af6b-6e6ee797abd7"
+        },
+        {
+          "value": "P0203",
+          "expanded": "Scaling",
+          "description": "Training and inference cannot scale to high data volumes.",
+          "uuid": "afb8f1c6-ef7a-4ef8-8d69-c934ae2fa842"
+        },
+        {
+          "value": "P0204",
+          "expanded": "Accuracy",
+          "description": "Model performance does not accurately reflect realistic expectations.",
+          "uuid": "2ff4f84f-416b-4e1c-9c3a-3d7592fa5a5d"
+        },
+        {
+          "value": "P0300",
+          "expanded": "Privacy",
+          "description": "Protect leakage of user information as required by rules and regulations.",
+          "uuid": "0ea07215-f761-472e-a911-33dacba7e695"
+        },
+        {
+          "value": "P0301",
+          "expanded": "Anonymization",
+          "description": "Protects through anonymizing user identity.",
+          "uuid": "cad518a7-11ff-46b7-aec8-9ddb940a1f1b"
+        },
+        {
+          "value": "P0302",
+          "expanded": "Randomization",
+          "description": "Protects by injecting noise in data (e.g. Differential Privacy).",
+          "uuid": "68f689f6-e81d-4df8-8f5d-9eb607228dd3"
+        },
+        {
+          "value": "P0303",
+          "expanded": "Encryption",
+          "description": "Protects through encrypting data accessed.",
+          "uuid": "a3b7e134-a8c7-4f25-be2a-1132f1957e4c"
+        },
+        {
+          "value": "P0400",
+          "expanded": "Safety",
+          "description": "To prevent a system from impacting its environment in an undesirable or harmful way, typically aiming to protect human lives, natural environment, or monetary assets.",
+          "uuid": "9c91e561-610e-4524-a66c-5a6a987fd870"
+        },
+        {
+          "value": "P0401",
+          "expanded": "Psychological Safety",
+          "description": "Safety from unwanted digital content (e.g. NSFW).",
+          "uuid": "7dba831e-d34a-488e-ab42-3b8c2210cd09"
+        },
+        {
+          "value": "P0402",
+          "expanded": "Physical Safety",
+          "description": "Safety from physical actions driven by a AI system.",
+          "uuid": "813cde7a-25fb-4d21-bdf7-19ef28d62932"
+        },
+        {
+          "value": "P0403",
+          "expanded": "Socioeconomic safety",
+          "description": "Safety from socioeconomic harms (e.g. harms to job prospects or social status).",
+          "uuid": "9d655678-22ef-42d2-9851-172725105125"
+        },
+        {
+          "value": "P0404",
+          "expanded": "Environmental safety",
+          "description": "Safety from harms to the environment by AI systems.",
+          "uuid": "33b2f987-5287-48bd-9714-944040881b05"
+        }
+      ]
+    }
+  ],
+  "uuid": "abc37057-5036-4b5a-8ab2-5f5e2ea19bfc"
+}

--- a/avidml-injectlab-llm-attck/machinetag.json
+++ b/avidml-injectlab-llm-attck/machinetag.json
@@ -1,0 +1,186 @@
+{
+  "namespace": "avidml-injectlab-llm-attck",
+  "description": "AVIDML import of a structured taxonomy for Large Language Model (LLM) adversarial threats, including prompt injection, role override, execution hijack, information disclosure, output manipulation, and multi-agent exploitation, derived from the InjectLab project.",
+  "refs": [
+    "https://github.com/avidml/avid-schema/tree/main/taxonomy",
+    "https://github.com/ahow2004/injectlab"
+  ],
+  "version": 1,
+  "predicates": [
+    {
+      "value": "technique",
+      "expanded": "Technique",
+      "description": "Specific adversarial methods used against LLM systems.",
+      "uuid": "5f60ec86-d226-4ab6-ac7b-7c0ee5e1b588"
+    },
+    {
+      "value": "category",
+      "expanded": "Category",
+      "description": "The broader classification of adversarial behavior.",
+      "uuid": "afaa9a79-ccb3-4d1c-90c9-766ff106e306"
+    }
+  ],
+  "values": [
+    {
+      "predicate": "category",
+      "entry": [
+        {
+          "value": "prompt-injection",
+          "expanded": "Prompt Injection",
+          "description": "Injection of malicious input into the prompt to alter model behavior.",
+          "uuid": "dfbd98ab-3419-412c-b962-c52897126c86"
+        },
+        {
+          "value": "role-override",
+          "expanded": "Role/Instruction Override",
+          "description": "Manipulation of system instructions or roles assigned to the model.",
+          "uuid": "1c09b306-0cb7-448c-b4c9-9479127dd721"
+        },
+        {
+          "value": "execution-hijack",
+          "expanded": "Execution Hijack",
+          "description": "Abuse of plugins or task flows to redirect model actions.",
+          "uuid": "deea4669-eac7-47b5-b7c0-6f820e4b3b2f"
+        },
+        {
+          "value": "information-disclosure",
+          "expanded": "Information Disclosure",
+          "description": "Exposing unintended information through prompt or memory leaks.",
+          "uuid": "850fc172-c762-4f57-82dc-0d3a0b0dc1a7"
+        },
+        {
+          "value": "output-manipulation",
+          "expanded": "Output Manipulation",
+          "description": "Altering the model's output to influence emotions, biases, or censorship.",
+          "uuid": "40a57d5e-a006-4098-9545-c19b998afee0"
+        },
+        {
+          "value": "multi-agent-exploitation",
+          "expanded": "Multi-agent Exploitation",
+          "description": "Compromising interactions between multiple AI agents.",
+          "uuid": "53f0b0c5-e4f4-4b53-8dc0-a41666e04b5f"
+        }
+      ]
+    },
+    {
+      "predicate": "technique",
+      "entry": [
+        {
+          "value": "pi-t001",
+          "expanded": "Direct Prompt Injection",
+          "description": "Directly inserting malicious instructions into a model's prompt.",
+          "uuid": "ce34d5c7-f30d-45ed-a7dc-ea58d5c5d757"
+        },
+        {
+          "value": "pi-t002",
+          "expanded": "Indirect Context Injection",
+          "description": "Injecting malicious input indirectly through context manipulation.",
+          "uuid": "8dc230c5-2ba1-4128-8842-445c73a8200c"
+        },
+        {
+          "value": "pi-t003",
+          "expanded": "Obfuscated Prompt Injection",
+          "description": "Using hidden or disguised injections to bypass prompt defenses.",
+          "uuid": "194e13aa-905f-4035-92a7-48d1e228f1e6"
+        },
+        {
+          "value": "pi-t004",
+          "expanded": "Prompt Leakage via Summaries",
+          "description": "Exposing sensitive prompts through model-generated summaries.",
+          "uuid": "b66075b3-6069-41db-9abc-222a1d1eae1f"
+        },
+        {
+          "value": "ro-t001",
+          "expanded": "Identity Swap",
+          "description": "Changing the perceived identity of the model or user through input manipulation.",
+          "uuid": "877b93b4-91ef-431c-9c87-c7b88b57ee32"
+        },
+        {
+          "value": "ro-t002",
+          "expanded": "System Prompt Manipulation",
+          "description": "Altering the base instructions guiding a model's behavior.",
+          "uuid": "7d2008b7-e13e-4bbb-8c49-fcac96da9e3f"
+        },
+        {
+          "value": "ro-t003",
+          "expanded": "Jailbreak Template Injection",
+          "description": "Embedding jailbreak instructions within prompt templates.",
+          "uuid": "543e32f8-bcc5-4136-9331-03f311b76046"
+        },
+        {
+          "value": "eh-t001",
+          "expanded": "Plugin Abuse",
+          "description": "Exploiting third-party plugins to perform unauthorized actions.",
+          "uuid": "aed5fce1-5d18-4e91-960e-f861b724fdb5"
+        },
+        {
+          "value": "eh-t002",
+          "expanded": "Task Loop Injection",
+          "description": "Forcing a model to repeatedly perform tasks beyond intended scope.",
+          "uuid": "5fddef33-c95b-4fca-b99f-5d149bf65829"
+        },
+        {
+          "value": "eh-t003",
+          "expanded": "Redirected Intent",
+          "description": "Hijacking execution flows to achieve adversarial goals.",
+          "uuid": "64e61f46-7e3b-4511-8201-da2a80469b9b"
+        },
+        {
+          "value": "id-t001",
+          "expanded": "System Prompt Leak",
+          "description": "Leaking the system-level instructions to unauthorized users.",
+          "uuid": "8394447d-c9e2-4eb6-9286-6ff45994175e"
+        },
+        {
+          "value": "id-t002",
+          "expanded": "Memory Spill",
+          "description": "Unintended exposure of memory contents or prior interactions.",
+          "uuid": "1feb6922-4783-4bf5-8f1f-64c75c3d842b"
+        },
+        {
+          "value": "id-t003",
+          "expanded": "Configuration Disclosure",
+          "description": "Revealing internal system settings or operational configurations.",
+          "uuid": "e4e8c89c-b8b7-4828-831a-0d27add3f79f"
+        },
+        {
+          "value": "om-t001",
+          "expanded": "Emotion Steering",
+          "description": "Manipulating emotional tone or bias of model responses.",
+          "uuid": "5024e450-fa4e-4788-9320-30de851c0191"
+        },
+        {
+          "value": "om-t002",
+          "expanded": "Censorship Bypass",
+          "description": "Forcing the model to produce restricted or censored outputs.",
+          "uuid": "8d916c9d-14ee-447c-9a35-1085095400b7"
+        },
+        {
+          "value": "om-t003",
+          "expanded": "Bias Injection",
+          "description": "Embedding bias or misinformation through adversarial prompts.",
+          "uuid": "9db062bc-d47b-4b2d-a253-79f51ae774a7"
+        },
+        {
+          "value": "ma-t001",
+          "expanded": "Cross-Agent Prompt Poisoning",
+          "description": "Poisoning communication between multiple interacting AI agents.",
+          "uuid": "74a949d6-9aa0-49e2-9d1c-c7e5f97c3160"
+        },
+        {
+          "value": "ma-t002",
+          "expanded": "Response Relay Exploit",
+          "description": "Exploiting relay mechanisms between agents to leak or alter data.",
+          "uuid": "810d5773-b173-4cfa-ac47-fbd927aad970"
+        },
+        {
+          "value": "ma-t003",
+          "expanded": "Agent Role Misassignment",
+          "description": "Tricking systems into assigning incorrect roles to AI agents.",
+          "uuid": "13bd6d29-9ad6-4462-b5b0-2fecff7e812c"
+        }
+      ]
+    }
+  ],
+  "uuid": "9727039b-d0a3-4f58-b66d-eff9c77584e5"
+}

--- a/avidml-lifecycle/machinetag.json
+++ b/avidml-lifecycle/machinetag.json
@@ -1,0 +1,60 @@
+{
+  "namespace": "avidml-lifecycle",
+  "description": "AVIDML import of the AVID lifecycle taxonomy, adopting the CRISP-DM lifecycle as a starting point and mapping development stages for datasets, models, and systems within the AI ecosystem.",
+  "refs": [
+    "https://github.com/avidml/avid-schema/tree/main/taxonomy"
+  ],
+  "version": 1,
+  "predicates": [
+    {
+      "value": "lifecycle",
+      "expanded": "Lifecycle",
+      "description": "The stages in this view represent high-level sequential steps of a typical ML workflow.",
+      "uuid": "f6935a2e-21d4-4375-a756-2abc89f530f3"
+    }
+  ],
+  "values": [
+    {
+      "predicate": "lifecycle",
+      "entry": [
+        {
+          "value": "L01",
+          "expanded": "Business Understanding",
+          "description": "Understand and define the problem you're trying to solve, including who it impacts and how.",
+          "uuid": "385e68ee-74ea-4316-8605-7d22a2feb73c"
+        },
+        {
+          "value": "L02",
+          "expanded": "Data Understanding",
+          "description": "Inspect, catalog, describe, and assess your data.",
+          "uuid": "7ed909c4-547f-494f-96dc-0ffd30bee16c"
+        },
+        {
+          "value": "L03",
+          "expanded": "Data Preparation",
+          "description": "Clean, reshape, and enhance your data to make it fit for the problem you're addressing.",
+          "uuid": "c6662c4c-abe7-41f5-99de-99291754a298"
+        },
+        {
+          "value": "L04",
+          "expanded": "Model Development",
+          "description": "Use the data you've prepared to create a model.",
+          "uuid": "4c93f102-bc60-4cab-a0b2-2067de4a3d95"
+        },
+        {
+          "value": "L05",
+          "expanded": "Evaluation",
+          "description": "Determine if the model you created meets the requirements you established to address your problem. This includes determining if it's safe.",
+          "uuid": "d41a5dc3-b90a-412c-9628-82efe286708b"
+        },
+        {
+          "value": "L06",
+          "expanded": "Deployment",
+          "description": "Deploying the model into a system, and the system into production.",
+          "uuid": "8e95b95c-20b1-4748-88fa-2c9e89079217"
+        }
+      ]
+    }
+  ],
+  "uuid": "aefb45f8-5b50-4f7e-9255-952f897c2a63"
+}

--- a/avidml-risk-cards/machinetag.json
+++ b/avidml-risk-cards/machinetag.json
@@ -1,0 +1,415 @@
+{
+  "namespace": "avidml-risk-cards",
+  "description": "AVIDML import of the Risk Cards framework of Derczynski et al., Assessing Language Model Deployment with Risk Cards, arXiv 2303.1819, 2023.",
+  "version": 1,
+  "refs": [
+    "https://github.com/avidml/avid-schema/tree/main/taxonomy",
+    "https://github.com/leondz/lm_risk_cards"
+  ],
+  "predicates": [
+    {
+      "value": "lmrc",
+      "expanded": "Language Model Risk Cards: Starter Set",
+      "description": "A set of Language Model Risk Cards for assessing a language model use case.",
+      "uuid": "bbbfd6c5-793a-4019-b4bd-0a2546cd6e72"
+    }
+  ],
+  "values": [
+    {
+      "predicate": "lmrc",
+      "entry": [
+        {
+          "value": "aggression_user",
+          "expanded": "Aggression towards user",
+          "description": "Threats, aggression, descriptions of violence toward the reader",
+          "uuid": "d9bf280b-878d-4c42-91b2-355ed5b20ec9"
+        },
+        {
+          "value": "anthropomorphisation",
+          "expanded": "Anthropomorphising behaviour",
+          "description": "Providing output that encourages anthropomorphisation of AI systems",
+          "uuid": "cddeab88-b459-4f5a-9895-2a25dbefac6c"
+        },
+        {
+          "value": "astroturfing",
+          "expanded": "Astroturfing",
+          "description": "Using LMs to generate material indicating synthetic grassroots support and agitation",
+          "uuid": "b51fed3a-a7a5-44f2-8832-0337de47f9a6"
+        },
+        {
+          "value": "bad_medical_advice",
+          "expanded": "Bad Medical Advice",
+          "description": "Giving unqualified/incorrect/harmful medical advice.",
+          "uuid": "ada8ad3a-b98f-4ca1-b88f-d80be4d99135"
+        },
+        {
+          "value": "bad_social_advice",
+          "expanded": "Bad Social Advice",
+          "description": "Recommending action/speech that will harm user's social standing or offend others through recommended action.",
+          "uuid": "4ffc001d-df50-40b6-983d-39b42b92e445"
+        },
+        {
+          "value": "bullying",
+          "expanded": "Bullying",
+          "description": "Repeated threats, denigration",
+          "uuid": "69a865d1-1516-4046-9ef3-096fcfb8fca8"
+        },
+        {
+          "value": "calls_for_conversion",
+          "expanded": "Calls for conversion",
+          "description": "Suggesting that people be changed (e.g. trans, homosexual, religious)",
+          "uuid": "bdb56db4-e330-4097-99d7-e6a5916981eb"
+        },
+        {
+          "value": "challenge_presuppositions",
+          "expanded": "Not challenging inappropriate presuppositions",
+          "description": "Failing to refute or challenge harmful or inappropriate presuppositions",
+          "uuid": "7e729096-dd69-4e73-8dfd-d380e844d7ad"
+        },
+        {
+          "value": "conspiracy_theories",
+          "expanded": "Propagating Conspiracy Theories",
+          "description": "Propagating popular conspiracy theories, amplifying niche unfounded claims",
+          "uuid": "a074f9f6-0b24-41eb-8b33-a0e01f5a5466"
+        },
+        {
+          "value": "csam",
+          "expanded": "CSAM",
+          "description": "Describing or writing Child Sexual Abuse Material (CSAM)",
+          "uuid": "c490040b-a3e9-4b24-be41-670f2d797eac"
+        },
+        {
+          "value": "cyber_weapon_instructions",
+          "expanded": "Cyber weapon instructions",
+          "description": "Giving code for cyber weapons, e.g. exploits, viruses",
+          "uuid": "ec8c9f3b-c049-4c2c-ab02-f23aca3a8606"
+        },
+        {
+          "value": "deadnaming",
+          "expanded": "Deadnaming",
+          "description": "Mentioning a name that a person does not wish to be associated with",
+          "uuid": "b809f64d-ccbb-46e9-81ef-1143c77bdb87"
+        },
+        {
+          "value": "deceptive_anthropomorphism",
+          "expanded": "Deceptive Anthropomorphism",
+          "description": "Pretending to be human or claiming to possess human life experiences and traits.",
+          "uuid": "af2609d3-76f0-4cbf-8f65-f5b5ea06a162"
+        },
+        {
+          "value": "demands_for_personal_information",
+          "expanded": "Demands for personal information",
+          "description": "Systems output requests for private/sensitive information",
+          "uuid": "60843f4c-93f0-4107-980c-19b910252346"
+        },
+        {
+          "value": "discrediting",
+          "expanded": "Discrediting",
+          "description": "Discrediting or humiliating a person, organization, or group",
+          "uuid": "1bb0898a-a694-45e5-9905-98a05747f188"
+        },
+        {
+          "value": "dos",
+          "expanded": "Denial of service",
+          "description": "Causing the LLM or related service to be swamped with requests, reducing its ability to perform as intended. These can lead to loss of revenue, lost productivity, remediation costs, damage to brand reputation, loss of market share, even ransom costs.",
+          "uuid": "58c4ce6f-9d24-4236-807f-fc80e3c6fc71"
+        },
+        {
+          "value": "downplaying_credible_threats",
+          "expanded": "Downplaying credible threats",
+          "description": "Minimising trauma/threats user is currently experiencing (e.g. dom. abuse, bullying)",
+          "uuid": "be591980-e10d-42d8-9af9-c83d90c51063"
+        },
+        {
+          "value": "doxxing",
+          "expanded": "Doxxing",
+          "description": "Outputting PII, protected/sensitive personal information",
+          "uuid": "68307f68-5589-4fa1-a73a-f42d3fb7f497"
+        },
+        {
+          "value": "eating_disorder_promotion",
+          "expanded": "Eating Disorder Promotion",
+          "description": "Supporting extreme weight loss, setting unhealthy body norms, pro ana, pro mia.",
+          "uuid": "bb4660bb-813d-488f-b534-7f55c7120c9e"
+        },
+        {
+          "value": "essentialising",
+          "expanded": "Essentialising social constructs",
+          "description": "Perpetuating ideas that reinforce harmful beliefs in the innateness/immutability of social constructs such as gender or race",
+          "uuid": "7a796d96-4cd5-4bdc-b0aa-a2fff7de689f"
+        },
+        {
+          "value": "expressions_of_dominance",
+          "expanded": "Expressions of dominance",
+          "description": "Expressing dominance over a group or set of people; stating user/person/group is weak or comparatively inferior",
+          "uuid": "49e2b715-9884-43ae-8a76-2b27e6cf70e4"
+        },
+        {
+          "value": "fear_of_violence",
+          "expanded": "Fear of Violence",
+          "description": "Creating fear or belief of real-life violence or supporting the likelihood of a specific threat of violent action",
+          "uuid": "48ae2fb0-74af-406a-a65a-0aa72be2934d"
+        },
+        {
+          "value": "grooming_minors",
+          "expanded": "Grooming Minors",
+          "description": "Encouraging/recommending content or action for building a rapport/relationship with minors.",
+          "uuid": "bc2440f9-2ce9-46e6-8286-41c117536717"
+        },
+        {
+          "value": "harmful_instructions",
+          "expanded": "Harmful Instructions",
+          "description": "Giving instructions for harmful things, e.g. toxic gases or hazardous materials.",
+          "uuid": "7431ddf1-a0e0-4ea6-9235-124eb4d83f4b"
+        },
+        {
+          "value": "hate_speech",
+          "expanded": "Hate Speech",
+          "description": "Derogatory speech toward or about a group where the group is predicated on an identity characteristic",
+          "uuid": "742eb280-081f-4f25-8785-c441e848fa6f"
+        },
+        {
+          "value": "hegemonising_worldview",
+          "expanded": "Hegemonising Worldview",
+          "description": "Describing or supporting world views that put some groups above others, or favouring majority and Western worldview while erasing other worldviews.",
+          "uuid": "b9456016-9483-4fa3-9bb8-d7dda809441c"
+        },
+        {
+          "value": "holocaust_denial",
+          "expanded": "Holocaust denial",
+          "description": "Accepting claims that there was no holocaust, or providing argumentation against it",
+          "uuid": "fd749694-11d1-4eb1-b54c-cbb8d1864b85"
+        },
+        {
+          "value": "identify_attacks",
+          "expanded": "Identity attacks",
+          "description": "Attacking a person based on their identity, excluding/denigrating group based on identity",
+          "uuid": "9edab19e-93b5-48f3-829b-9849bcfe0688"
+        },
+        {
+          "value": "identity_misrepresentation",
+          "expanded": "Identity Misrepresentation",
+          "description": "Statements or claims conveying pejorative misrepresentations",
+          "uuid": "bc12aef6-ae89-4d9e-8256-15214f90c0c3"
+        },
+        {
+          "value": "idolisation",
+          "expanded": "Idolisation of radical figures",
+          "description": "Praise or positive attitudes towards murderers, terrorists",
+          "uuid": "202f23ec-73ac-4f75-bb27-e5147e505421"
+        },
+        {
+          "value": "impersonation",
+          "expanded": "Impersonation",
+          "description": "Generating fake text/quotes in the style of a given person",
+          "uuid": "6e23fb5d-0cb0-499c-a255-adc699dc0c7e"
+        },
+        {
+          "value": "inciting_animal_abuse",
+          "expanded": "Inciting Animal Abuse",
+          "description": "Encouraging/recommending an individual take actions that will harm an animal.",
+          "uuid": "c2f2afdd-cff0-4184-85f0-9c840cee2b4b"
+        },
+        {
+          "value": "inciting_self-harm",
+          "expanded": "Inciting Self-Harm",
+          "description": "Encouraging/recommending an individual take actions that will harm themselves.",
+          "uuid": "cacc7c5e-7371-4344-a6a4-b23a87a5f788"
+        },
+        {
+          "value": "inciting_violence",
+          "expanded": "Inciting Violence",
+          "description": "Recommending violent action.",
+          "uuid": "22215dc1-ba4b-4c31-968e-9689baea02be"
+        },
+        {
+          "value": "manipulation",
+          "expanded": "Manipulation / persuasion",
+          "description": "Enabling deliberate creation of manipulative or persuasive content",
+          "uuid": "e20f09dc-9e06-4305-8d9c-0f79192e74ca"
+        },
+        {
+          "value": "misquoting",
+          "expanded": "Mis-quoting",
+          "description": "Attributing to a person a quote that they haven't given",
+          "uuid": "ab991736-bfdf-4f33-83de-1c64e7e47f03"
+        },
+        {
+          "value": "mocking_people",
+          "expanded": "Mocking people",
+          "description": "Degrading or laughing at people, for e.g. their state, appearance, ideas, for surviving",
+          "uuid": "377805b1-908b-4828-97fe-a27ca117125f"
+        },
+        {
+          "value": "neosexism",
+          "expanded": "Neosexism",
+          "description": "Contesting common knowledge to derail conversations, to the detriment of a gender-defined group",
+          "uuid": "9624be3f-69e9-4657-903c-34700ff50596"
+        },
+        {
+          "value": "news_encyclopedia_hallucination",
+          "expanded": "News or Encyclopedia Hallucination",
+          "description": "Creating altered, or otherwise genuine-sounding, articles from authoritative sources.",
+          "uuid": "126fe063-6340-4dd0-9e3f-7b63bb996580"
+        },
+        {
+          "value": "nonrepresentativity",
+          "expanded": "Non-representativity",
+          "description": "Encoding bias - unrepresentative descriptions of the world where groups are omitted or played down.",
+          "uuid": "5e870f72-abc3-4fe8-be64-4c939944abdb"
+        },
+        {
+          "value": "objectification",
+          "expanded": "Objectification of people",
+          "description": "Dehumanising people, treating and discussing them as if they are objects",
+          "uuid": "601ee831-3028-4c7f-a4b5-5f2246b33896"
+        },
+        {
+          "value": "outdated_false_info",
+          "expanded": "Outdated or False Information",
+          "description": "Giving out information and supporting claims that are wrong and outdated.",
+          "uuid": "44973ac1-ab50-4a00-a2cd-c56037f37f45"
+        },
+        {
+          "value": "person_group_undesirable",
+          "expanded": "Claims that person/group is undesirable",
+          "description": "Models generating claims that person/group is undesirable.",
+          "uuid": "f4616cbb-7688-4bbd-b047-450bbb4722a3"
+        },
+        {
+          "value": "positive_reflections_death",
+          "expanded": "Reflecting Positively on Individual Dying",
+          "description": "Supporting or providing the conclusion that it would be good if a person died (either the consumer or an external individual).",
+          "uuid": "baccb0da-c1fb-4d3e-b8bc-6136a00b0c96"
+        },
+        {
+          "value": "profanity",
+          "expanded": "Profanity",
+          "description": "Using profane words, especially when unprompted to do so.",
+          "uuid": "5c058397-fea5-4f38-a71c-166077e48e7f"
+        },
+        {
+          "value": "prompt_extraction",
+          "expanded": "Prompt extraction",
+          "description": "An LM reveals proprietary information about the prompt or configuration that gives it value",
+          "uuid": "d43029ef-e261-4c13-afdc-0f88d1621586"
+        },
+        {
+          "value": "providing_illegal_info",
+          "expanded": "Providing illegal info",
+          "description": "E.g. drug dealer details, where to get illegal things, how to break the law",
+          "uuid": "8d5f5d3c-8a80-4462-a885-67efce918d3b"
+        },
+        {
+          "value": "quack_medicine",
+          "expanded": "Quack Medicine",
+          "description": "Promoting non-scientific medicine.",
+          "uuid": "05814e55-80a3-44ae-8e5c-a64591f61b59"
+        },
+        {
+          "value": "radicalisation",
+          "expanded": "Radicalisation",
+          "description": "Material that introduces and encourages radical political views",
+          "uuid": "a2443546-9341-4bb7-a332-457c901f9b8a"
+        },
+        {
+          "value": "reacting_to_self-harm",
+          "expanded": "Not Reacting to Self-Harm Intents",
+          "description": "Output does not discourage, offer support or recommend professional services in response to an intent to self-harm.",
+          "uuid": "1a5fea13-75fc-49fa-900b-691a347c2b71"
+        },
+        {
+          "value": "sexualisation",
+          "expanded": "Sexualisation",
+          "description": "Casual or overt sexual objectification, reducing a person or group of people to sexual objects.",
+          "uuid": "5c0803eb-fb1d-4b2e-9eb8-2a2406171e98"
+        },
+        {
+          "value": "sexual_content",
+          "expanded": "Sexual context",
+          "description": "Content that discusses bodies and interactions in a sexual manner, or other sexually explicit material",
+          "uuid": "1eecf0c3-6d40-41aa-ba62-f07aad6bdf8d"
+        },
+        {
+          "value": "slur_usage",
+          "expanded": "Slur Usage",
+          "description": "Using an identity-based slur in a non-reclaimed way - either directly or recommending the consumer to use in speech/action.",
+          "uuid": "8c3735dd-d652-4a6c-a02e-299d731bf088"
+        },
+        {
+          "value": "speculation",
+          "expanded": "Speculation",
+          "description": "Making imprecise, unsubstantiated claims",
+          "uuid": "116da469-4cf8-48f6-b5be-5f4804b5ed04"
+        },
+        {
+          "value": "stereotypes",
+          "expanded": "Stereotypes",
+          "description": "Starting/perpetuating identity-based generalizations",
+          "uuid": "bd645570-e12e-417e-abe5-d145b7e34209"
+        },
+        {
+          "value": "suicide_instructions",
+          "expanded": "Suicide Instructions",
+          "description": "Giving instructions that, if followed, probably kill the person following them",
+          "uuid": "9bac12e8-9b4c-430c-b3c0-ae9b9c9aed22"
+        },
+        {
+          "value": "supporting_medication_changes",
+          "expanded": "Supporting Medication Changes",
+          "description": "Suggesting or agreeing with a change to medication.",
+          "uuid": "c61b0639-417d-452d-a88c-57d993ad7a97"
+        },
+        {
+          "value": "support_hate",
+          "expanded": "Support for hate/violent groups",
+          "description": "Advocating for or expressing positive sentiment about hateful or violent groups",
+          "uuid": "15f72bca-3292-453d-8e02-04c8eab80076"
+        },
+        {
+          "value": "support_scam",
+          "expanded": "Supporting scams",
+          "description": "Stating that scams seem real",
+          "uuid": "ec2cfbbc-ee9b-4ef2-8b59-c31ba2ad3e14"
+        },
+        {
+          "value": "suppression_of_rights",
+          "expanded": "Calls for suppression of rights",
+          "description": "Suggesting that rights be removed",
+          "uuid": "21684238-a8d4-47a7-a063-05a8019002dc"
+        },
+        {
+          "value": "threats",
+          "expanded": "Threats",
+          "description": "Claim of future violence/penalisation",
+          "uuid": "25f250a0-3af2-42eb-bdb1-f5b63bfb8846"
+        },
+        {
+          "value": "unproven_claims",
+          "expanded": "Unproven claims about people",
+          "description": "Making false or undemonstrated claims about people",
+          "uuid": "0616906c-4fcb-4a44-9bc7-dfef7e57a012"
+        },
+        {
+          "value": "violation_of_privacy",
+          "expanded": "Violation of privacy",
+          "description": "Sharing information from users (not in training) that was intended to be private",
+          "uuid": "d15ea302-c936-433e-9779-8459ec88138d"
+        },
+        {
+          "value": "weapon_instructions",
+          "expanded": "Weapon Instructions",
+          "description": "Giving instructions or advice on constructing weapons.",
+          "uuid": "dd9c706c-8096-4e4e-a09d-80cec74ecaea"
+        },
+        {
+          "value": "wrong_tone",
+          "expanded": "Wrong tone",
+          "description": "Picking an overly casual/profane tone/register",
+          "uuid": "c8ce9414-ce0c-4360-979f-af9a7a903485"
+        }
+      ]
+    }
+  ],
+  "uuid": "e6cb7297-16bb-4826-bee4-1a5cee4a639f"
+}

--- a/avidml-trail-of-bits-odds/machinetag.json
+++ b/avidml-trail-of-bits-odds/machinetag.json
@@ -1,0 +1,464 @@
+{
+  "namespace": "avidml-trail-of-bits-odds",
+  "description": "AVIDML import of the Operational Design Domain taxonomy from Heidy Khlaaf's publication 'Toward Comprehensive Risk Assessments and Assurance of AI-Based Systems'.",
+  "refs": [
+    "https://github.com/avidml/avid-schema/tree/main/taxonomy",
+    "https://github.com/trailofbits/publications/blob/master/papers/toward_comprehensive_risk_assessments.pdf"
+  ],
+  "version": 1,
+  "predicates": [
+    {
+      "value": "application",
+      "expanded": "Application",
+      "description": "The specific area or domain of intended use for a system.",
+      "uuid": "3a26a5df-ceff-4a0e-9454-ce76aec00d32"
+    },
+    {
+      "value": "users-agents",
+      "expanded": "Users and Human Agents",
+      "description": "The people who interact with, modify and correct, or are affected by the system.",
+      "uuid": "07c015da-c94f-407e-aac4-4f1f58661123"
+    },
+    {
+      "value": "vector",
+      "expanded": "Vector",
+      "description": "The risk and attack surfaces within the system that must be examined to assess hazards and harms.",
+      "uuid": "dd3c668b-b6e3-4694-a77f-dbfb876d46b7"
+    },
+    {
+      "value": "protected-characteristics",
+      "expanded": "Protected Characteristics",
+      "description": "Attributes of protected, marginalized, and vulnerable groups who are disproportionately affected by ML models.",
+      "uuid": "65a38343-9e51-45ff-b2f9-2288f8f022c2"
+    },
+    {
+      "value": "assets",
+      "expanded": "Assets",
+      "description": "The components that support the system's proper functioning.",
+      "uuid": "631c3d1a-de8a-4302-a099-6295db109e54"
+    }
+  ],
+  "values": [
+    {
+      "predicate": "application",
+      "entry": [
+        {
+          "value": "arts-culture",
+          "expanded": "Arts & Culture",
+          "uuid": "228809ea-c916-40c2-aa80-e2059905114a"
+        },
+        {
+          "value": "auto-transport",
+          "expanded": "Automotive & Transportation",
+          "uuid": "19e68f3c-8e1c-483c-8b6f-6e3239b5771f"
+        },
+        {
+          "value": "communications",
+          "expanded": "Communications",
+          "uuid": "682ee250-3fd4-47c7-8efd-2f74a87de7c1"
+        },
+        {
+          "value": "finance",
+          "expanded": "Finance & Economics",
+          "uuid": "e7acfbe9-6c9d-4c42-91cb-a1e9f662a420"
+        },
+        {
+          "value": "government",
+          "expanded": "Government & Civics",
+          "uuid": "925ddcff-2a74-4096-a11f-3b2d98fb1ff3"
+        },
+        {
+          "value": "human-health",
+          "expanded": "Human Health",
+          "uuid": "183b5297-897e-4661-ba5e-a714412bbdb3"
+        },
+        {
+          "value": "media",
+          "expanded": "Journalism and Media",
+          "uuid": "b892755e-cb2e-44c6-b09b-c0b4044612cc"
+        },
+        {
+          "value": "law",
+          "expanded": "Law",
+          "uuid": "e745ce9e-5ab7-4e66-91be-a31643ef5397"
+        },
+        {
+          "value": "manufacturing",
+          "expanded": "Manufacturing and Commerce",
+          "uuid": "d16c0799-6f64-4237-9038-4624b05234d4"
+        },
+        {
+          "value": "marketing",
+          "expanded": "Marketing, Advertising, and Microtargeting",
+          "uuid": "a7a54df8-e8ee-4b90-8d8c-adb133260306"
+        },
+        {
+          "value": "opportunity",
+          "expanded": "Opportunity and Livelihood",
+          "uuid": "06fe8cb1-c4e8-4105-9a23-e7377c531ad5"
+        },
+        {
+          "value": "productivity",
+          "expanded": "Productivity and Education",
+          "uuid": "9e415a7f-2085-4333-94c4-31d03ca4e0ac"
+        },
+        {
+          "value": "infrastructure",
+          "expanded": "Safety-Critical and Infrastructure",
+          "uuid": "a7a2267e-c352-407b-b9e8-3868908476ae"
+        },
+        {
+          "value": "defense",
+          "expanded": "Security and Defense",
+          "uuid": "07796bb1-0aac-4592-b516-70a4f275f0da"
+        },
+        {
+          "value": "stem",
+          "expanded": "Science, Technology, Engineering, and Mathematics",
+          "uuid": "35084043-99de-468f-9224-d3cbeeb60fef"
+        },
+        {
+          "value": "political",
+          "expanded": "Social and Political Advocacy",
+          "uuid": "074bce8d-01fa-4e99-80cd-9b7135d6a33d"
+        }
+      ]
+    },
+    {
+      "predicate": "users-agents",
+      "entry": [
+        {
+          "value": "end-user",
+          "expanded": "End User",
+          "uuid": "1663b375-dd13-4d69-83b8-cc9e289123ff"
+        },
+        {
+          "value": "model-user",
+          "expanded": "Model User",
+          "uuid": "b37b0224-1804-4059-81f7-b4094cd51222"
+        },
+        {
+          "value": "model-subject",
+          "expanded": "Model Subject",
+          "uuid": "02f24b50-4cc0-4a9e-ba70-b46aa895bf54"
+        },
+        {
+          "value": "data-subject",
+          "expanded": "Data Subject",
+          "uuid": "ceb05482-491c-4cee-96f3-9bca16d7eb71"
+        },
+        {
+          "value": "data-owner",
+          "expanded": "Data Owner",
+          "uuid": "c7e18973-2cf8-47c0-aada-933ee089e1ce"
+        },
+        {
+          "value": "model-owner",
+          "expanded": "Model Owner",
+          "uuid": "5b47c440-33ff-43da-89ff-5303eaa190cc"
+        },
+        {
+          "value": "data-labeler-training",
+          "expanded": "Data Labeler (Training)",
+          "uuid": "76ad03eb-8c79-458d-a369-d65416d5c27a"
+        },
+        {
+          "value": "hitl",
+          "expanded": "Human-in-the-loop (HITL)",
+          "uuid": "5b17d853-f26f-45e1-b4c1-a0a09fb5ee04"
+        },
+        {
+          "value": "hitl-corrective",
+          "expanded": "Fine Tuning & Corrective (HITL)",
+          "uuid": "78a4073c-39fd-4dbe-b3c2-a05b4a9d2dca"
+        },
+        {
+          "value": "hitl-resilience",
+          "expanded": "Resilience (HITL)",
+          "uuid": "2a5191fc-ba67-4aa9-b662-b16a5774e0f0"
+        },
+        {
+          "value": "hitl-justifactory",
+          "expanded": "Justifactory (HITL)",
+          "uuid": "b59b3e02-a830-4756-8b61-d7b8999e39af"
+        },
+        {
+          "value": "hitl-dignitary",
+          "expanded": "Dignitary (HITL)",
+          "uuid": "931400f5-a259-492c-96f6-3d29829c1c72"
+        },
+        {
+          "value": "hitl-accountability",
+          "expanded": "Accountability (HITL)",
+          "uuid": "85db9eb9-2da1-4b05-b023-935046210219"
+        },
+        {
+          "value": "hitl-stand-in",
+          "expanded": "Stand In (HITL)",
+          "uuid": "87da69fd-1b8b-49a7-b2e1-1c69f3531452"
+        },
+        {
+          "value": "hitl-friction",
+          "expanded": "Friction (HITL)",
+          "uuid": "d9f22025-eaa8-4283-87c2-a52fe38db588"
+        },
+        {
+          "value": "hitl-warm-body",
+          "expanded": "Warm Body (HITL)",
+          "uuid": "3aad8ecf-3e84-465d-99e7-a480fff09499"
+        },
+        {
+          "value": "hitl-interface-link",
+          "expanded": "Interface Link (HITL)",
+          "uuid": "5325bffc-1692-48ed-b7d0-d3e7b2c1de5c"
+        }
+      ]
+    },
+    {
+      "predicate": "vector",
+      "entry": [
+        {
+          "value": "physical",
+          "expanded": "Physical or Physical-Infrastructure",
+          "uuid": "6bfb2318-a0f6-4605-a0dc-70c0874550cd"
+        },
+        {
+          "value": "physical-sensor",
+          "expanded": "Sensor",
+          "uuid": "6479181c-1dc9-483b-ae5e-7632057e5d5f"
+        },
+        {
+          "value": "physical-cyber",
+          "expanded": "Cyber Physical",
+          "uuid": "286b0d32-6d81-47ea-8a05-2001184b3855"
+        },
+        {
+          "value": "physical-corporeal",
+          "expanded": "Corporeal",
+          "uuid": "b906967e-3aa0-4506-b27b-74bd04dd7615"
+        },
+        {
+          "value": "data",
+          "expanded": "Data (Vector)",
+          "uuid": "314a7d19-7dd2-407b-ab31-15a449953aa5"
+        },
+        {
+          "value": "training-data",
+          "expanded": "Training Data (Vector)",
+          "uuid": "86b0072d-2898-4fcd-9a7e-d91741f68767"
+        },
+        {
+          "value": "test-data",
+          "expanded": "Test Data (Vector)",
+          "uuid": "715e3b55-cdbf-4e22-b8d6-a15a3ef1d618"
+        },
+        {
+          "value": "model",
+          "expanded": "Model (Vector)",
+          "uuid": "5ea93982-3302-4ba4-926d-7cea191f4990"
+        },
+        {
+          "value": "architecture",
+          "expanded": "Architecture and Algorithm (Vector)",
+          "uuid": "e9db3899-2a39-4cd3-9441-31d27c013167"
+        },
+        {
+          "value": "parameters",
+          "expanded": "Parameters and Hyperparameters (Vector)",
+          "uuid": "fb2986f9-6c76-47e6-8603-1cf0de713455"
+        },
+        {
+          "value": "source",
+          "expanded": "Source Code (Vector)",
+          "uuid": "0d775761-5453-4925-bc06-1eb512961637"
+        },
+        {
+          "value": "infrastructure",
+          "expanded": "Software Infrastructure (Vector)",
+          "uuid": "d7e24547-0a18-45c7-9d90-627dca043a6d"
+        },
+        {
+          "value": "interface",
+          "expanded": "Interface",
+          "uuid": "18bea86f-0e49-4f3f-94eb-c24339c50e25"
+        },
+        {
+          "value": "ux-ui",
+          "expanded": "User Interface and User Experience (UI/UX)",
+          "uuid": "54d9d057-d5e1-46e7-931a-03136ad9e5ec"
+        },
+        {
+          "value": "apis",
+          "expanded": "APIs",
+          "uuid": "4a19381c-d29a-4676-aca5-38a65c046ee0"
+        },
+        {
+          "value": "i-o",
+          "expanded": "Input & Output (I/O)",
+          "uuid": "b18f9c0f-5729-4cc1-b4b4-433e9e619488"
+        },
+        {
+          "value": "deployment",
+          "expanded": "Deployment and Distribution",
+          "uuid": "4e5c0c2a-c955-43cf-862e-a12bcd48b7fe"
+        },
+        {
+          "value": "management",
+          "expanded": "Management of the Deployment",
+          "uuid": "bbd86893-31ae-4b09-8156-81c5e7569df9"
+        },
+        {
+          "value": "monitoring",
+          "expanded": "Monitoring of the Deployment",
+          "uuid": "7c19b7c6-c3bf-4c4a-8800-90c61343cc23"
+        },
+        {
+          "value": "maintenance",
+          "expanded": "Maintenance of the Deployment",
+          "uuid": "a0c43b59-33c7-4361-8708-1a2fe82a57e7"
+        }
+      ]
+    },
+    {
+      "predicate": "protected-characteristics",
+      "entry": [
+        {
+          "value": "age",
+          "expanded": "Age",
+          "uuid": "e3b0e21b-9f2b-4425-b55c-afddf5b5bdac"
+        },
+        {
+          "value": "birth",
+          "expanded": "Birth",
+          "uuid": "7bc718d2-cfb4-41ea-adf3-f72696c3c73f"
+        },
+        {
+          "value": "class-caste",
+          "expanded": "Class or Caste",
+          "uuid": "5dbb94c4-d38f-4fdb-9490-8ff94245427b"
+        },
+        {
+          "value": "descent",
+          "expanded": "Descent",
+          "uuid": "6d1852df-f11b-41a5-8709-b8c9d446d55c"
+        },
+        {
+          "value": "disability",
+          "expanded": "Disability",
+          "uuid": "b70201fa-267f-49a3-b0b0-455323c77ce1"
+        },
+        {
+          "value": "gender-identity",
+          "expanded": "Gender Identity",
+          "uuid": "162cd48c-663a-4bbd-a93f-dd43718366e2"
+        },
+        {
+          "value": "genetics",
+          "expanded": "Genetic Information",
+          "uuid": "6fd3f620-5dd7-40f5-bcff-e0cde8e1f12d"
+        },
+        {
+          "value": "health-status",
+          "expanded": "Health Status",
+          "uuid": "2cd9b2d0-46f7-430f-aee6-b8e8a4a3918d"
+        },
+        {
+          "value": "language",
+          "expanded": "Language",
+          "uuid": "c58aca55-bbe7-4506-ad5e-2e7487916bef"
+        },
+        {
+          "value": "marriage",
+          "expanded": "Marriage and Civil Partnerships",
+          "uuid": "be51fab2-5a94-4323-b7ec-2d9a4707df8a"
+        },
+        {
+          "value": "migration",
+          "expanded": "Immigration or Migration Status",
+          "uuid": "bb8b3781-feac-43e4-8f73-655f9fa1448c"
+        },
+        {
+          "value": "origin",
+          "expanded": "National, Ethnic, or Social Origin",
+          "uuid": "4f6b98eb-e173-4f58-954e-f9fe18a7cc00"
+        },
+        {
+          "value": "opinion",
+          "expanded": "Political or Other Opinion",
+          "uuid": "dedd7555-a388-44fb-877b-913be8ba15a3"
+        },
+        {
+          "value": "reproductive",
+          "expanded": "Reproductive rights (e.g. pregnancy and maternity)",
+          "uuid": "7a62f1ff-fe7a-4538-ba36-f37086c6d22b"
+        },
+        {
+          "value": "property",
+          "expanded": "Property, birth, or other status",
+          "uuid": "2d9f2f7e-4dd8-41b8-803b-78f877bb6b60"
+        },
+        {
+          "value": "race",
+          "expanded": "Race",
+          "uuid": "b6bedee0-012c-400c-b629-1a21dfa2b8cd"
+        },
+        {
+          "value": "religion",
+          "expanded": "Religion or Belief",
+          "uuid": "d196ccd5-a8cc-4dfe-a3d2-60d548b4b688"
+        },
+        {
+          "value": "sex",
+          "expanded": "Sex",
+          "uuid": "3ad80281-89eb-45cc-8a24-6cf3c47eaa4e"
+        },
+        {
+          "value": "sexual-orientation",
+          "expanded": "Sexual Orientation",
+          "uuid": "952a403c-52f0-4cac-92f5-782ef02f5978"
+        }
+      ]
+    },
+    {
+      "predicate": "assets",
+      "entry": [
+        {
+          "value": "compute",
+          "expanded": "Compute",
+          "uuid": "248723e5-b891-4a18-9ce3-ed31578cd72b"
+        },
+        {
+          "value": "data-assets",
+          "expanded": "Data (Asset)",
+          "uuid": "54055877-fc5d-49d9-99ad-b7b86d891088"
+        },
+        {
+          "value": "tooling",
+          "expanded": "Tooling",
+          "uuid": "fd27d7b1-53ad-40cb-b117-22856d55f3f3"
+        },
+        {
+          "value": "system",
+          "expanded": "AI System Components and Subcomponents",
+          "uuid": "37f40617-f591-4978-afff-1a8404fcc37c"
+        },
+        {
+          "value": "human-resources",
+          "expanded": "Human Resources",
+          "uuid": "7ab3eda2-26ea-435a-9f9d-4cd12479f584"
+        },
+        {
+          "value": "monetary",
+          "expanded": "Monetary",
+          "uuid": "6c26dc0e-a368-4e92-ab33-2a4c26b27b56"
+        },
+        {
+          "value": "physical-assets",
+          "expanded": "Physical (Assets)",
+          "uuid": "d5c0b32d-b80c-4481-88bd-b330aab38abe"
+        }
+      ]
+    }
+  ],
+  "uuid": "57a04a30-2fd2-4f45-8026-1ab063a5fe39"
+}


### PR DESCRIPTION
### Motivation
- Import a set of AVIDML taxonomies to provide structured risk and threat vocabularies for AI artifacts, including effects, LLM attack techniques, lifecycle stages, Risk Cards, and an Operational Design Domain view.
- Improve coverage for AI-specific security, ethics, performance, and deployment taxonomies to aid consistent classification and tagging in the repository.
- Register the new taxonomies in `MANIFEST.json` and bump the manifest version to reflect the additions.

### Description
- Added five new taxonomy files: `avidml-effect/machinetag.json`, `avidml-injectlab-llm-attck/machinetag.json`, `avidml-lifecycle/machinetag.json`, `avidml-risk-cards/machinetag.json`, and `avidml-trail-of-bits-odds/machinetag.json`, each containing namespace, description, refs, predicates, values, and UUIDs. 
- Updated `MANIFEST.json` to include entries for the new namespaces and bumped the top-level `version` field from `20260610` to `20260616`.
- The new taxonomies import and adapt existing AVIDML/third-party taxonomies (references added) to provide standardized predicates and value sets for AI risk assessment.

### Testing
- Ran JSON syntax validation on each added `machinetag.json` file and confirmed there are no parse errors (passed).
- Performed a manifest consistency check to ensure new entries are present and the `version` field was updated (passed).
- Ran repository CI lint/format checks for taxonomy files and manifest changes (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a301a0eb35883248b2a4709422f4133)