### PR TITLE
acs-marking: add missing shareability values used by AIS

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -46,7 +46,7 @@
     {
       "description": "The Access Control Specification (ACS) marking type defines the object types required to implement automated access control systems based on the relevant policies governing sharing between participants.",
       "name": "acs-marking",
-      "version": 1
+      "version": 2
     },
     {
       "description": "Action taken in the case of a security incident (CSIRT perspective).",
@@ -910,5 +910,5 @@
     }
   ],
   "url": "https://raw.githubusercontent.com/MISP/misp-taxonomies/main/",
-  "version": "20260714"
+  "version": "20260731"
 }

--- a/acs-marking/machinetag.json
+++ b/acs-marking/machinetag.json
@@ -1,7 +1,7 @@
 {
   "namespace": "acs-marking",
   "description": "The Access Control Specification (ACS) marking type defines the object types required to implement automated access control systems based on the relevant policies governing sharing between participants.",
-  "version": 1,
+  "version": 2,
   "predicates": [
     {
       "value": "privilege_action",
@@ -276,6 +276,24 @@
           "value": "IC",
           "expanded": "Intelligence Community",
           "uuid": "779eb97f-5d41-5cbf-b39b-e6401c78c457"
+        },
+        {
+          "value": "USA.USG",
+          "expanded": "United States Government",
+          "description": "As used in DHS/CISA Automated Indicator Sharing (AIS) ACS 3.0 markings, denoting shareability with U.S. federal government entities.",
+          "uuid": "238e94cf-7aca-500a-b20f-d61d3370bf0a"
+        },
+        {
+          "value": "SECTOR",
+          "expanded": "Sector Partners",
+          "description": "As used in DHS/CISA Automated Indicator Sharing (AIS) ACS 3.0 markings, denoting shareability with critical infrastructure sector partners (e.g. ISACs/ISAOs).",
+          "uuid": "88a50537-0dba-52d1-96fc-b6158040bac5"
+        },
+        {
+          "value": "FOREIGNGOV",
+          "expanded": "Foreign Government",
+          "description": "As used in DHS/CISA Automated Indicator Sharing (AIS) ACS 3.0 markings, denoting shareability with foreign government partners.",
+          "uuid": "35dc71e4-bee5-5e7d-adeb-f7402da597cc"
         }
       ]
     },


### PR DESCRIPTION
The `acs-marking:shareability=` predicate currently only defines four
values: `NCC`, `EM`, `LE`, `IC`. Real-world ACS 3.0 markings from DHS/CISA's
Automated Indicator Sharing (AIS) TAXII feed use `sharing_scope` values
that aren't in that list: `USA.USG`, `SECTOR`, and `FOREIGNGOV`

This adds the three missing values with UUIDs generated the same way as
the rest of the file (`uuid5(NAMESPACE_DNS, f'{namespace}:{predicate}="{value}"')`),
and bumps `acs-marking`'s version from 1 to 2.

## Changes
- `acs-marking/machinetag.json`: add `USA.USG`, `SECTOR`, `FOREIGNGOV` under
  the `shareability` predicate; bump version 1 → 2.
- `MANIFEST.json`: updated to reflect version bump`.
