### PR TITLE
chore(agent-threat-rules): the licence field says Apache 2.0, ATR is MIT

### DIFF
--- a/MANIFEST.json
+++ b/MANIFEST.json
@@ -64,9 +64,9 @@
       "version": 6
     },
     {
-      "description": "Agent Threat Rules (ATR) is an open detection standard for AI agent threats published under Apache 2.0. The taxonomy organises 713 community-maintained rules across ten attack categories covering prompt injection, tool poisoning, skill compromise, context exfiltration, agent manipulation, privilege escalation, excessive autonomy, model abuse, model security, and data poisoning. Predicates name the category; values are individual rule identifiers in the form ATR-YYYY-NNNNN.",
+      "description": "Agent Threat Rules (ATR) is an open detection standard for AI agent threats published under the MIT licence. The taxonomy organises 713 community-maintained rules across ten attack categories covering prompt injection, tool poisoning, skill compromise, context exfiltration, agent manipulation, privilege escalation, excessive autonomy, model abuse, model security, and data poisoning. Predicates name the category; values are individual rule identifiers in the form ATR-YYYY-NNNNN.",
       "name": "agent-threat-rules",
-      "version": 2
+      "version": 3
     },
     {
       "description": "A list of standalone definitions for each type of bias. Aggregate terms that are in common usage or relevance to AI bias. From NIST.SP.1270-draft (2021)",
@@ -915,5 +915,5 @@
     }
   ],
   "url": "https://raw.githubusercontent.com/MISP/misp-taxonomies/main/",
-  "version": "20260817"
+  "version": "20260818"
 }

--- a/agent-threat-rules/machinetag.json
+++ b/agent-threat-rules/machinetag.json
@@ -1,5 +1,5 @@
 {
-  "description": "Agent Threat Rules (ATR) is an open detection standard for AI agent threats published under Apache 2.0. The taxonomy organises 713 community-maintained rules across ten attack categories covering prompt injection, tool poisoning, skill compromise, context exfiltration, agent manipulation, privilege escalation, excessive autonomy, model abuse, model security, and data poisoning. Predicates name the category; values are individual rule identifiers in the form ATR-YYYY-NNNNN.",
+  "description": "Agent Threat Rules (ATR) is an open detection standard for AI agent threats published under the MIT licence. The taxonomy organises 713 community-maintained rules across ten attack categories covering prompt injection, tool poisoning, skill compromise, context exfiltration, agent manipulation, privilege escalation, excessive autonomy, model abuse, model security, and data poisoning. Predicates name the category; values are individual rule identifiers in the form ATR-YYYY-NNNNN.",
   "expanded": "Agent Threat Rules",
   "namespace": "agent-threat-rules",
   "predicates": [
@@ -4399,5 +4399,5 @@
       "predicate": "tool-poisoning"
     }
   ],
-  "version": 2
+  "version": 3
 }


### PR DESCRIPTION
@adulau — a correction to something I got wrong in #323.

The agent-threat-rules taxonomy description says ATR is "published under
Apache 2.0". It is not, and never has been. The project ships MIT: LICENSE
reads "MIT License / Copyright (c) 2026 ATR Contributors" and package.json
declares "license": "MIT".

I wrote that sentence, so this is my error rather than an upstream one.
Anyone reading the taxonomy to decide whether they can redistribute these
rule identifiers is currently being told the wrong terms, and Apache 2.0 and
MIT differ in exactly the places that decision turns on.

What changed

  MANIFEST.json                      | 6 +++---
  agent-threat-rules/machinetag.json | 4 ++--

The licence sentence, and version 2 to 3.

MANIFEST.json carried the same sentence. Since that is the file instances
actually fetch, correcting only the taxonomy would have left the wrong
licence in front of users. I regenerated it with tools/gen_manifest.py
rather than editing it by hand, so the only other change in that file is the
usual date stamp.

Predicates, entries, UUIDs and the namespace are untouched. No instance that
has tagged events with this taxonomy is affected.

validate_all.py passes.

Two things I deliberately did not do here

1. The taxonomy is at 713 entries; ATR is now at 777 effective rules. I would
   rather send that as its own PR than mix a freshness update into a
   correctness fix, since the two need different amounts of review. Happy to
   open it whenever suits you.

2. The UUIDs in this taxonomy do not match what gen_uuid.py produces. That
   script derives them as uuid5(NAMESPACE_DNS, f'{namespace}:{predicate}="{value}"'),
   and ours are uuid5 under some namespace I can no longer recover. For
   context I checked the whole repo: 159 taxonomies match gen_uuid.py and 23
   do not, and mine is one of the 23.

   I have not touched them, because aligning would change every entry UUID
   and break any instance that has already tagged events with the current
   ones. If you would like them brought in line, tell me and I will open a
   separate PR so the breakage is a deliberate, visible decision rather than
   a side effect of a licence fix.
